### PR TITLE
UIROLES-104: remove placeholderData from useRoleCapabilities hook, as it causes a missleading isSuccess flag

### DIFF
--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -44,13 +44,11 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
       },
     ).json(),
     enabled: Boolean(enabled && !!roleId),
-    placeholderData: {
-      capabilities: [], totalRecords: 0,
-    },
     ...otherOptions,
   });
 
   const initialRoleCapabilitiesSelectedMap = useMemo(() => {
+    if (!data) return {};
     return data?.capabilities.reduce((acc, capability) => {
       acc[capability.id] = true;
 
@@ -63,6 +61,7 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
   }, [data]);
 
   const capabilitiesAppIds = useMemo(() => {
+    if (!data) return {};
     const capabilitiesById = mapValues(keyBy(data?.capabilities, 'applicationId'), () => true) || {};
     const filteredByInstalledApplications = pick(capabilitiesById, installedApplications);
 

--- a/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
+++ b/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
@@ -23,7 +23,7 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  * @param {object} options Any additional options to pass into `useQuery()`.
  * @returns Capability Sets.
  */
-export const useRoleCapabilitySets = (roleId, tenant, options = {}) => {
+export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
   const { enabled = true, ...otherOptions } = options;
   const stripes = useStripes();
   const installedApplications = Object.keys(stripes.discovery.applications);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose

[UIROLES-104](https://folio-org.atlassian.net/browse/UIROLES-104) - Capabilities/sets not loaded in role edit view if a role has only capabilities
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

_isSuccess_ flag used as indicator if data is fetched. However, if you provide **placeholderData** to the useQuery hook, the initial _isSuccess_ flag is always true and setting applications to the state in RoleEdit was triggered before the role capabilities is fetched. 
[Here is the comment from the maintainer of react-query lib](https://github.com/TanStack/query/issues/1712#issuecomment-1356786317) 
Just remove placeholderData, and add guards if no data exist

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
