### PR TITLE
UIROLES-107: add tenantId to the query key to invalidate list of roles after deleting role

### DIFF
--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useHistory } from 'react-router';
+import { isEmpty } from 'lodash';
 
 import {
   useApplicationCapabilities,
@@ -73,9 +74,11 @@ export const RoleCreate = ({ path }) => {
     if (callback) {
       callback();
     }
-    setSelectedCapabilitiesMap({});
-    setSelectedCapabilitySetsMap({});
-    setDisabledCapabilities({});
+    if (isEmpty(appIds)) {
+      setSelectedCapabilitiesMap({});
+      setSelectedCapabilitySetsMap({});
+      setDisabledCapabilities({});
+    }
     setCheckedAppIdsMap(appIds);
   };
 

--- a/lib/hooks/useAuthorizationRoles/useAuthorizationRoles.js
+++ b/lib/hooks/useAuthorizationRoles/useAuthorizationRoles.js
@@ -14,7 +14,7 @@ import { ROLES_ENDPOINT } from '../../constants';
 
 export const useAuthorizationRoles = (tenantId) => {
   const ky = useOkapiKy({ tenant: tenantId });
-  const [namespace] = useNamespace({ key: 'authorization-roles' });
+  const [namespace] = useNamespace();
   const stripes = useStripes();
   const [searchTerm, setSearchTerm] = useState('');
   const [roles, setRoles] = useState([]);

--- a/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
+++ b/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
@@ -1,14 +1,14 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 
-export const useDeleteRoleMutation = (callback, handleError) => {
+export const useDeleteRoleMutation = (callback, handleError, tenantId) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
   const [namespace] = useNamespace();
   const { mutateAsync, isLoading } = useMutation({
     mutationFn: (id) => ky.delete(`roles/${id}`).json(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries(namespace);
+      await queryClient.invalidateQueries([namespace, tenantId]);
       callback();
     },
     onError: handleError,

--- a/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
+++ b/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
@@ -4,7 +4,7 @@ import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 export const useDeleteRoleMutation = (callback, handleError, tenantId) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
-  const [namespace] = useNamespace();
+  const [namespace] = useNamespace({ key: 'authorization-roles' });
   const { mutateAsync, isLoading } = useMutation({
     mutationFn: (id) => ky.delete(`roles/${id}`).json(),
     onSuccess: async () => {

--- a/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
+++ b/lib/hooks/useDeleteRoleMutation/useDeleteRoleMutation.js
@@ -1,14 +1,14 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 
-export const useDeleteRoleMutation = (callback, handleError, tenantId) => {
+export const useDeleteRoleMutation = (callback, handleError) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
-  const [namespace] = useNamespace({ key: 'authorization-roles' });
+  const [namespace] = useNamespace();
   const { mutateAsync, isLoading } = useMutation({
     mutationFn: (id) => ky.delete(`roles/${id}`).json(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries([namespace, tenantId]);
+      await queryClient.invalidateQueries([namespace]);
       callback();
     },
     onError: handleError,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIROLES-107](https://folio-org.atlassian.net/browse/UIROLES-107) - Authorization role is not removed from roles list right after being deleted. 


## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

Since to fetch roles list data used [tenantId parameter](https://github.com/folio-org/stripes-authorization-components/blob/9fb6d7ab2d06dd6f1e8a47e40f0e789f0ca601f3/lib/hooks/useAuthorizationRoles/useAuthorizationRoles.js#L25) provide the same parameter to delete mutation hook to invalidate roles list data query. 


<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
