### PR TITLE
UISAUTHCOM-9: conditionally set values of selected capabilities/sets to true if checked and remove from object if NOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 * [UISAUTHCOM-6](https://folio-org.atlassian.net/browse/UISAUTHCOM-6) add `expand` parameter to queryKey in useRoleCapabilities hook.
 * [UISAUTHCOM-7](https://folio-org.atlassian.net/browse/UISAUTHCOM-7) Fix definition and calls to useRoleCapabilities/useRoleCapabilitySets so correct value is used for X-Okapi-Tenant.
 * [UISAUTHCOM-10](https://folio-org.atlassian.net/browse/UISAUTHCOM-10) clean up query cache on close edit role mode, provide `virtualize` property to capabilities/sets tables. 
+* [UISAUTHCOM-9](https://folio-org.atlassian.net/browse/UISAUTHCOM-9) conditionally set values of selected capabilities/sets to true if checked and remove from object if NOT

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -73,7 +73,13 @@ export const RoleEdit = ({ path }) => {
   const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitySetsMap);
 
   const onChangeCapabilityCheckbox = (event, id) => {
-    setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
+    if (event.target.checked) {
+      setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: true });
+    } else {
+      // eslint-disable-next-line
+      const { [id]: _capabilityToRemove, ...newSelectedCapabilities } = selectedCapabilitySetsMap;
+      setSelectedCapabilitiesMap(newSelectedCapabilities);
+    }
   };
 
   const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
@@ -86,7 +92,15 @@ export const RoleEdit = ({ path }) => {
     }, {});
 
     setDisabledCapabilities({ ...disabledCapabilities, ...capabilitySetsCap });
-    setSelectedCapabilitySetsMap({ ...selectedCapabilitySetsMap, [capabilitySetId]: event.target.checked });
+    // If checked set selected capability set id to true {foo: true}
+    // If unchecked remove selected capability set id from selectedCapabilitySetsMap {} instead of {foo: false}
+    if (event.target.checked) {
+      setSelectedCapabilitySetsMap({ ...selectedCapabilitySetsMap, [capabilitySetId]: true });
+    } else {
+      // eslint-disable-next-line
+      const { [capabilitySetId]: _capabilitySetToRemove, ...newSelectedCapabilitySetsMap } = selectedCapabilitySetsMap;
+      setSelectedCapabilitySetsMap(newSelectedCapabilitySetsMap);
+    }
   };
 
   const isCapabilityDisabled = id => !!disabledCapabilities[id];

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -58,7 +58,9 @@ export const RoleEdit = ({ path }) => {
   } = useApplicationCapabilitySets(checkedAppIdsMap);
 
   const onSubmitSelectApplications = (appIds, onCloseHandler) => {
-    onCloseHandler?.();
+    if (onCloseHandler) {
+      onCloseHandler();
+    }
     if (isEmpty(appIds)) {
       setSelectedCapabilitiesMap({});
       setSelectedCapabilitySetsMap({});
@@ -73,13 +75,15 @@ export const RoleEdit = ({ path }) => {
   const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitySetsMap);
 
   const onChangeCapabilityCheckbox = (event, id) => {
+    const updatedSelectedCapabilitiesMap = { ...selectedCapabilitiesMap };
+
     if (event.target.checked) {
-      setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: true });
+      updatedSelectedCapabilitiesMap[id] = true;
     } else {
-      // eslint-disable-next-line
-      const { [id]: _capabilityToRemove, ...newSelectedCapabilities } = selectedCapabilitySetsMap;
-      setSelectedCapabilitiesMap(newSelectedCapabilities);
+      delete updatedSelectedCapabilitiesMap[id];
     }
+
+    setSelectedCapabilitiesMap(updatedSelectedCapabilitiesMap);
   };
 
   const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
@@ -94,13 +98,15 @@ export const RoleEdit = ({ path }) => {
     setDisabledCapabilities({ ...disabledCapabilities, ...capabilitySetsCap });
     // If checked set selected capability set id to true {foo: true}
     // If unchecked remove selected capability set id from selectedCapabilitySetsMap {} instead of {foo: false}
+    const newSelectedCapabilitySetsMap = { ...selectedCapabilitySetsMap };
+
     if (event.target.checked) {
-      setSelectedCapabilitySetsMap({ ...selectedCapabilitySetsMap, [capabilitySetId]: true });
+      newSelectedCapabilitySetsMap[capabilitySetId] = true;
     } else {
-      // eslint-disable-next-line
-      const { [capabilitySetId]: _capabilitySetToRemove, ...newSelectedCapabilitySetsMap } = selectedCapabilitySetsMap;
-      setSelectedCapabilitySetsMap(newSelectedCapabilitySetsMap);
+      delete newSelectedCapabilitySetsMap[capabilitySetId];
     }
+
+    setSelectedCapabilitySetsMap(newSelectedCapabilitySetsMap);
   };
 
   const isCapabilityDisabled = id => !!disabledCapabilities[id];

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -351,4 +351,26 @@ describe('RoleEdit', () => {
     expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(2);
     expect(mockSetSelectedCapabilitySetsMap).toHaveBeenLastCalledWith({});
   });
+
+  it('should call on submit select application on mocked Pluggable component ', async () => {
+    useRoleCapabilities.mockReturnValue({
+      initialRoleCapabilitiesSelectedMap: {},
+      isSuccess: true
+    });
+    useRoleCapabilitySets.mockReturnValue({
+      initialRoleCapabilitySetsSelectedMap: {},
+      isSuccess: true,
+      capabilitySetsAppIds: {}
+    });
+    const { getByTestId } = render(renderWithRouter(
+      <RoleEdit path="/auz/roles/1" />
+    ));
+    expect(getByTestId('pluggable-submit-button')).toBeInTheDocument();
+    await act(async () => {
+      await userEvent.click(getByTestId('pluggable-submit-button'));
+    });
+
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenLastCalledWith({});
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenLastCalledWith({});
+  });
 });

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -5,15 +5,12 @@ import { renderWithRouter } from 'helpers';
 import {
   useApplicationCapabilities,
   useApplicationCapabilitySets,
-  useCapabilities,
-  useCapabilitySets,
   useEditRoleMutation,
   useRoleById,
   useRoleCapabilities,
   useRoleCapabilitySets,
 } from '../../hooks';
 import { RoleEdit } from './RoleEdit';
-
 
 const mockPutRequest = jest.fn().mockReturnValue({ ok:true });
 const mockPostRequest = jest.fn().mockReturnValue({ ok:true });
@@ -91,20 +88,6 @@ describe('RoleEdit', () => {
 
   beforeEach(() => {
     useEditRoleMutation.mockReturnValue({ mutateRole: mockMutateRole, isLoading: false });
-    useCapabilities.mockReturnValue({
-      capabilitiesList: [
-        {
-          id: '6e59c367-888a-4561-a3f3-3ca677de437f',
-          applicationId: 'app-platform-complete-0.0.5',
-          name: 'foo_item.delete',
-          description: 'Settings: Delete foo item',
-          resource: 'Settings source',
-          action: 'edit',
-          type: 'settings',
-        }
-      ],
-      isSuccess: true
-    });
     useRoleCapabilities.mockReturnValue({
       initialRoleCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true },
       isSuccess: true
@@ -118,61 +101,32 @@ describe('RoleEdit', () => {
       isSuccess: true,
       capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true }
     });
-    useCapabilitySets.mockReturnValue({
-      capabilitySetsList: [
-        {
-          'id': 'd2e91897-c10d-46f6-92df-dad77c1e8862',
-          'description': 'Sample: Create foo item',
-          'resource': 'Erm Agreements Collection',
-          'action': 'create',
-          'type': 'data',
-          'applicationId': 'app-platform-complete-0.0.5',
-          'capabilities': [
-            '6e59c367-888a-4561-a3f3-3ca677de437f',
-            'db1ceca9-2bb1-4212-8203-755cd5bc5bf9',
-            '98af4c92-1df2-4916-96b4-886bec72ad29'
-          ]
-        }
-      ],
-      isSuccess: true
-    });
     useApplicationCapabilities.mockReturnValue({
       capabilities: {
         data:[{
           id:'6e59c367-888a-4561-a3f3-3ca677de437f',
           applicationId:'app-platform-complete-0.0.5',
-          resource:'Erm Agreements Collection',
+          resource:'Data type resource 1',
           actions:{ 'view':'6e59c367-888a-4561-a3f3-3ca677de437f' }
         },
         {
-          id:'db1ceca9-2bb1-4212-8203-755cd5bc5bf9',
+          id:'5c5198f9-de27-4349-9537-dc0b2b41c8c3',
           applicationId:'app-platform-complete-0.0.5',
-          resource:'Erm Agreements Item',
-          'actions':{ 'view':'db1ceca9-2bb1-4212-8203-755cd5bc5bf9' }
+          resource:'Data type resource 2',
+          'actions':{ 'edit':'5c5198f9-de27-4349-9537-dc0b2b41c8c3' }
         }],
         procedural:[{
           id:'98af4c92-1df2-4916-96b4-886bec72ad29',
           applicationId:'app-platform-complete-0.0.5',
-          resource:'Erm Agreements',
+          resource:'Procedural type resource',
           actions:{ execute:'98af4c92-1df2-4916-96b4-886bec72ad29' }
         }],
         settings:[]
       },
-      checkedAppIdsMap: { 'app-platform-complete-0.0.5': true },
       roleCapabilitiesListIds: ['5c5198f9-de27-4349-9537-dc0b2b41c8c3'],
-      capabilitySets: {
-        data: [{
-          id:'d2e91897-c10d-46f6-92df-dad77c1e8862',
-          applicationId:'app-platform-complete-0.0.5',
-          resource:'Erm Agreements Collection',
-          actions:{ view:'d2e91897-c10d-46f6-92df-dad77c1e8862' },
-          capabilities:['6e59c367-888a-4561-a3f3-3ca677de437f']
-        }],
-      },
       selectedCapabilitiesMap: { '5c5198f9-de27-4349-9537-dc0b2b41c8c3':true },
-      disabledCapabilities: {},
       setSelectedCapabilitiesMap:mockSetSelectedCapabilitiesMap,
-      setDisabledCapabilities: jest.fn()
+      isLoading: false
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -180,14 +134,14 @@ describe('RoleEdit', () => {
         data: [{
           id:'d2e91897-c10d-46f6-92df-dad77c1e8862',
           applicationId:'app-platform-complete-0.0.5',
-          resource:'Erm Agreements Collection',
+          resource:'Erm Agreements Collection set',
           actions:{ view:'d2e91897-c10d-46f6-92df-dad77c1e8862' },
-          capabilities:['6e59c367-888a-4561-a3f3-3ca677de437f']
+          capabilities:[]
         }]
       },
       setSelectedCapabilitySetsMap: mockSetSelectedCapabilitySetsMap,
       selectedCapabilitySetsMap: {},
-      roleCapabilitySetsListIds: ['d2e91897-c10d-46f6-92df-dad77c1e8862'],
+      roleCapabilitySetsListIds: [],
       isLoading: false,
       capabilitySetsList: [
         {
@@ -197,11 +151,7 @@ describe('RoleEdit', () => {
           'action': 'create',
           'type': 'data',
           'applicationId': 'app-platform-complete-0.0.5',
-          'capabilities': [
-            '6e59c367-888a-4561-a3f3-3ca677de437f',
-            'db1ceca9-2bb1-4212-8203-755cd5bc5bf9',
-            '98af4c92-1df2-4916-96b4-886bec72ad29'
-          ]
+          'capabilities': ['5c5198f9-de27-4349-9537-dc0b2b41c8c3']
         }
       ]
     });
@@ -277,7 +227,7 @@ describe('RoleEdit', () => {
     expect(getByTestId('pluggable-select-application')).toBeInTheDocument();
   });
 
-  it('should call capability sets checkbox handler', async () => {
+  it('should call capability/sets to local state on initial loading page, i.e. in useEffect', async () => {
     const { getAllByRole } = render(renderWithRouter(
       <RoleEdit path="/auz/roles/1" />
     ));
@@ -285,34 +235,120 @@ describe('RoleEdit', () => {
     const capabilitiesCheckboxLength = 3;
     const capabilitySetsCheckboxLength = 1;
 
-    expect(getAllByRole('checkbox')).toHaveLength(capabilitiesCheckboxLength + capabilitySetsCheckboxLength);
-
-    await act(async () => {
-      await userEvent.click(getAllByRole('checkbox')[0]);
-    });
-    // Should be called 2 times, first call is on isInitialDataReady in useEffect
-    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenNthCalledWith(1, {});
-    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenNthCalledWith(2, { 'd2e91897-c10d-46f6-92df-dad77c1e8862':true });
+    expect(getAllByRole('checkbox').length).toBe(capabilitiesCheckboxLength + capabilitySetsCheckboxLength);
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledTimes(1);
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ '6e59c367-888a-4561-a3f3-3ca677de437f':true });
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(1);
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenLastCalledWith({});
   });
 
-  it('should call initial load function from useApplicationCapabilities hook', async () => {
+  it('should call capabilities checkbox handler UNCHECK action on click', async () => {
+    useApplicationCapabilities.mockReturnValue({
+      capabilities: {
+        data:[
+          {
+            id:'5c5198f9-de27-4349-9537-dc0b2b41c8c3',
+            applicationId:'app-platform-complete-0.0.5',
+            resource:'Data type resource 2',
+            'actions':{ 'edit':'5c5198f9-de27-4349-9537-dc0b2b41c8c3' }
+          }],
+        procedural:[],
+        settings:[]
+      },
+      roleCapabilitiesListIds: ['5c5198f9-de27-4349-9537-dc0b2b41c8c3'],
+      selectedCapabilitiesMap: { '5c5198f9-de27-4349-9537-dc0b2b41c8c3':true },
+      setSelectedCapabilitiesMap:mockSetSelectedCapabilitiesMap,
+      isLoading: false
+    });
     const { getAllByRole } = render(renderWithRouter(
       <RoleEdit path="/auz/roles/1" />
     ));
-
-    const capabilitiesCheckboxLength = 3;
-    const capabilitySetsCheckboxLength = 1;
-
-    expect(getAllByRole('checkbox')).toHaveLength(capabilitiesCheckboxLength + capabilitySetsCheckboxLength);
 
     await act(async () => {
       await userEvent.click(getAllByRole('checkbox')[1]);
     });
-    // Should be called 2 times, first call is on isInitialDataReady in useEffect
-    expect(mockSetSelectedCapabilitiesMap).toHaveBeenNthCalledWith(1, { '6e59c367-888a-4561-a3f3-3ca677de437f': true });
-    expect(mockSetSelectedCapabilitiesMap).toHaveBeenNthCalledWith(2, {
-      '5c5198f9-de27-4349-9537-dc0b2b41c8c3': true,
-      '6e59c367-888a-4561-a3f3-3ca677de437f': true
+
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenLastCalledWith({});
+  });
+
+  it('should call capabilities checkbox handler CHECK action on click', async () => {
+    useApplicationCapabilities.mockReturnValue({
+      capabilities: {
+        data:[
+          {
+            id:'5c5198f9-de27-4349-9537-dc0b2b41c8c3',
+            applicationId:'app-platform-complete-0.0.5',
+            resource:'Data type resource 2',
+            'actions':{ 'edit':'5c5198f9-de27-4349-9537-dc0b2b41c8c3' }
+          }],
+        procedural:[],
+        settings:[]
+      },
+      roleCapabilitiesListIds: [],
+      selectedCapabilitiesMap: {},
+      setSelectedCapabilitiesMap:mockSetSelectedCapabilitiesMap,
+      isLoading: false
     });
+    const { getAllByRole } = render(renderWithRouter(
+      <RoleEdit path="/auz/roles/1" />
+    ));
+
+    await act(async () => {
+      await userEvent.click(getAllByRole('checkbox')[1]);
+    });
+
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenLastCalledWith({ '5c5198f9-de27-4349-9537-dc0b2b41c8c3':true });
+  });
+
+  it('should call capability sets checkbox handler CHECK action on click', async () => {
+    const { getAllByRole } = render(renderWithRouter(
+      <RoleEdit path="/auz/roles/1" />
+    ));
+
+    await act(async () => {
+      await userEvent.click(getAllByRole('checkbox')[0]);
+    });
+
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(2);
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenLastCalledWith({ 'd2e91897-c10d-46f6-92df-dad77c1e8862': true });
+  });
+
+  it('should call capability sets checkbox handler UNCHECK action on click', async () => {
+    useApplicationCapabilitySets.mockReturnValue({
+      capabilitySets: {
+        data: [{
+          id:'d2e91897-c10d-46f6-92df-dad77c1e8862',
+          applicationId:'app-platform-complete-0.0.5',
+          resource:'Erm Agreements Collection set',
+          actions:{ view:'d2e91897-c10d-46f6-92df-dad77c1e8862' },
+          capabilities:[]
+        }]
+      },
+      setSelectedCapabilitySetsMap: mockSetSelectedCapabilitySetsMap,
+      selectedCapabilitySetsMap: { 'd2e91897-c10d-46f6-92df-dad77c1e8862': true },
+      roleCapabilitySetsListIds: ['d2e91897-c10d-46f6-92df-dad77c1e8862'],
+      isLoading: false,
+      capabilitySetsList: [
+        {
+          'id': 'd2e91897-c10d-46f6-92df-dad77c1e8862',
+          'description': 'Sample: Create foo item',
+          'resource': 'Erm Agreements Collection',
+          'action': 'create',
+          'type': 'data',
+          'applicationId': 'app-platform-complete-0.0.5',
+          'capabilities': []
+        }
+      ]
+    });
+    const { getAllByRole } = render(renderWithRouter(
+      <RoleEdit path="/auz/roles/1" />
+    ));
+
+    await act(async () => {
+      await userEvent.click(getAllByRole('checkbox')[0]);
+    });
+
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(2);
+    expect(mockSetSelectedCapabilitySetsMap).toHaveBeenLastCalledWith({});
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-9](https://folio-org.atlassian.net/browse/UISAUTHCOM-9) - Cannot save a role after selecting and then deselecting a capability/capability set
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
The issue is that if you send the same initial data for capabilities and capability sets, the backend responds with a 400 Error, informing that nothing has changed. On the UI, we compare the initial data and the operating data state. If they are equal we don't trigger capabilities/sets BE PUT method endpoint.

 However, once you make changes in the state and try to revert to the initial state, the clicked ID of the capability settles in the state as {[id]: false}, instead of being removed from the object.
For example, if the initial data was an empty object {}, once you click a checkbox, the object becomes {[id]: true}. When deselecting, it changes to {[id]: false}. 

Since {} is not equal to {[id]: false}, the approach is to remove the ID from the object if the event value is false to make our comparison work.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
