### PR TITLE
UISAUTHCOM-10: clean up query client cache on close edit role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 * [UISAUTHCOM-1](https://folio-org.atlassian.net/browse/UISAUTHCOM-1)Move reusable components from UIROLES to a shared repository.
 * [UISAUTHCOM-6](https://folio-org.atlassian.net/browse/UISAUTHCOM-6) add `expand` parameter to queryKey in useRoleCapabilities hook.
 * [UISAUTHCOM-7](https://folio-org.atlassian.net/browse/UISAUTHCOM-7) Fix definition and calls to useRoleCapabilities/useRoleCapabilitySets so correct value is used for X-Okapi-Tenant.
-
+* [UISAUTHCOM-10](https://folio-org.atlassian.net/browse/UISAUTHCOM-10) clean up query cache on close edit role mode, provide `virtualize` property to capabilities/sets tables. 

--- a/lib/Capabilities/CapabilitiesDataType/CapabilitiesDataType.js
+++ b/lib/Capabilities/CapabilitiesDataType/CapabilitiesDataType.js
@@ -76,6 +76,7 @@ export const CapabilitiesDataType = ({
         contentData={content}
         visibleColumns={visibleColumns}
         columnWidths={columnWidths}
+        virtualize
       />
     </div>
   );

--- a/lib/Capabilities/CapabilitiesProcedural/CapabilitiesProcedural.js
+++ b/lib/Capabilities/CapabilitiesProcedural/CapabilitiesProcedural.js
@@ -77,6 +77,7 @@ export const CapabilitiesProcedural = ({
         formatter={resultsFormatter}
         interactive={false}
         visibleColumns={visibleColumns}
+        virtualize
       />
     </div>
   );

--- a/lib/Capabilities/CapabilitiesSettings/CapabilitiesSettings.js
+++ b/lib/Capabilities/CapabilitiesSettings/CapabilitiesSettings.js
@@ -89,6 +89,7 @@ export const CapabilitiesSettings = ({
         contentData={content}
         visibleColumns={visibleColumns}
         columnWidths={columnWidths}
+        virtualize
       />
     </div>
   );

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -2,7 +2,7 @@ import { isEmpty, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-
+import { useQueryClient } from 'react-query';
 import {
   useApplicationCapabilities,
   useApplicationCapabilitySets,
@@ -17,6 +17,7 @@ import { RoleForm } from '../RoleForm';
 export const RoleEdit = ({ path }) => {
   const history = useHistory();
   const { id: roleId } = useParams();
+  const queryClient = useQueryClient();
 
   const { roleDetails, isSuccess: isRoleDetailsLoaded } = useRoleById(roleId);
 
@@ -103,7 +104,10 @@ export const RoleEdit = ({ path }) => {
     }
   }, [isRoleDetailsLoaded, roleDetails]);
 
-  const onClose = () => history.push(`${path}/${roleId}`);
+  const onClose = () => {
+    queryClient.clear();
+    history.push(`${path}/${roleId}`);
+  };
 
   const { mutateRole, isLoading } = useEditRoleMutation(
     { id: roleId, name: roleName, description },

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -38,6 +38,13 @@ jest.mock('react-query', () => ({
   useMutation: jest.fn(() => ({ mutate: mockMutateFn, isLoading: false })),
 }));
 
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useQueryClient: jest.fn().mockReturnValue({
+    clear: jest.fn()
+  })
+}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn().mockReturnValue({ id: 1 }),


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-10](https://folio-org.atlassian.net/browse/UISAUTHCOM-10) - Loading animation for Capabilities and Capability sets not shown when editing role again. 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
After closing the edit mode, the retrieved data is cached. When we reopen the same role for editing, the first render is blocked by setting an enormously large list of cached data to the tables, causing the user to see a blank white screen until all tables are rendered. Therefore, clear the query cache when closing the role edit mode.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
