### PR TITLE
UISAUTHCOM-13: remove only capabilities related queries from react-query cache by using exposed query keys of chunked query hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 * [UISAUTHCOM-10](https://folio-org.atlassian.net/browse/UISAUTHCOM-10) clean up query cache on close edit role mode.
 * [UISAUTHCOM-9](https://folio-org.atlassian.net/browse/UISAUTHCOM-9) conditionally set values of selected capabilities/sets to true if checked and remove from object if NOT.
 * [UISAUTHCOM-11](https://folio-org.atlassian.net/browse/UISAUTHCOM-11) Move reusable components from `ui-authorization-policies` repository.
+* [UISAUTHCOM-13](https://folio-org.atlassian.net/browse/UISAUTHCOM-13) Cleanup only capabilities related queries from react-query cache on close edit role.
+
+

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -45,7 +45,8 @@ export const RoleEdit = ({ path }) => {
     selectedCapabilitiesMap,
     setSelectedCapabilitiesMap,
     roleCapabilitiesListIds,
-    isLoading: isAppCapabilitiesLoading
+    isLoading: isAppCapabilitiesLoading,
+    queryKeys:applicationCapabilitiesQueryKeys
   } = useApplicationCapabilities(checkedAppIdsMap);
 
   const {
@@ -55,6 +56,7 @@ export const RoleEdit = ({ path }) => {
     roleCapabilitySetsListIds,
     capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading,
+    queryKeys: applicationCapabilitySetsQueryKeys
   } = useApplicationCapabilitySets(checkedAppIdsMap);
 
   const onSubmitSelectApplications = (appIds, onCloseHandler) => {
@@ -125,7 +127,7 @@ export const RoleEdit = ({ path }) => {
   }, [isRoleDetailsLoaded, roleDetails]);
 
   const onClose = () => {
-    queryClient.clear();
+    queryClient.removeQueries({ queryKey:[...applicationCapabilitiesQueryKeys, ...applicationCapabilitySetsQueryKeys] });
     history.push(`${path}/${roleId}`);
   };
 

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -17,6 +17,7 @@ const mockPostRequest = jest.fn().mockReturnValue({ ok:true });
 const mockSetSelectedCapabilitiesMap = jest.fn();
 const mockSetSelectedCapabilitySetsMap = jest.fn();
 
+
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
   useCapabilities: jest.fn(),
@@ -35,11 +36,13 @@ jest.mock('react-query', () => ({
   useMutation: jest.fn(() => ({ mutate: mockMutateFn, isLoading: false })),
 }));
 
+const mockRemoveQueries = jest.fn();
 jest.mock('react-query', () => ({
   ...jest.requireActual('react-query'),
-  useQueryClient: jest.fn().mockReturnValue({
-    clear: jest.fn()
-  })
+  useQueryClient: jest.fn(() => ({
+    clear: jest.fn(),
+    removeQueries: mockRemoveQueries
+  }))
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -126,7 +129,8 @@ describe('RoleEdit', () => {
       roleCapabilitiesListIds: ['5c5198f9-de27-4349-9537-dc0b2b41c8c3'],
       selectedCapabilitiesMap: { '5c5198f9-de27-4349-9537-dc0b2b41c8c3':true },
       setSelectedCapabilitiesMap:mockSetSelectedCapabilitiesMap,
-      isLoading: false
+      isLoading: false,
+      queryKeys: []
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -153,7 +157,8 @@ describe('RoleEdit', () => {
           'applicationId': 'app-platform-complete-0.0.5',
           'capabilities': ['5c5198f9-de27-4349-9537-dc0b2b41c8c3']
         }
-      ]
+      ],
+      queryKeys: [['app-platform-complete-0.0.5']]
     });
   });
 
@@ -197,6 +202,9 @@ describe('RoleEdit', () => {
     });
 
     expect(submitButton).toBeEnabled();
+
+    await userEvent.click(cancelButton);
+    expect(mockRemoveQueries).toHaveBeenCalledWith({ 'queryKey': [['app-platform-complete-0.0.5']] });
   });
 
   it('onSubmit invalidates "ui-authorization-roles" query and calls goBack on success', async () => {

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -26,7 +26,7 @@ import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapab
 
 export const useApplicationCapabilities = (checkedAppIdsMap) => {
   const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
-  const { items: capabilities, isLoading: isCapabilitiesLoading } = useChunkedApplicationCapabilities(selectedAppIds);
+  const { items: capabilities, isLoading: isCapabilitiesLoading, queryKeys } = useChunkedApplicationCapabilities(selectedAppIds);
 
   const [selectedCapabilitiesMap, setSelectedCapabilitiesMap] = useState({});
   const roleCapabilitiesListIds = extractSelectedIdsFromObject(selectedCapabilitiesMap);
@@ -47,6 +47,7 @@ export const useApplicationCapabilities = (checkedAppIdsMap) => {
     selectedCapabilitiesMap,
     roleCapabilitiesListIds,
     setSelectedCapabilitiesMap,
-    isLoading: isCapabilitiesLoading
+    isLoading: isCapabilitiesLoading,
+    queryKeys
   };
 };

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
@@ -26,7 +26,7 @@ describe('useApplicationCapabilities', () => {
   });
 
   it('should test if returning fields and methods are defined', () => {
-    useChunkedApplicationCapabilities.mockReset().mockReturnValue({ items: [], isLoading: false });
+    useChunkedApplicationCapabilities.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
     const { result } = renderHook(useApplicationCapabilities, { initialProps: { cap1: true } });
 
     expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
@@ -34,6 +34,7 @@ describe('useApplicationCapabilities', () => {
     expect(result.current.selectedCapabilitiesMap).toStrictEqual({});
     expect(result.current.setSelectedCapabilitiesMap).toBeDefined();
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.queryKeys).toStrictEqual([['key1', 'key2']]);
   });
   it('should set checkedAppIdsMap and call onSubmitSelectApplications', async () => {
     const items = [
@@ -69,7 +70,7 @@ describe('useApplicationCapabilities', () => {
   });
 
   it('should set empty capabilities in the case of empty appIds', async () => {
-    useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items: [], isLoading: false });
+    useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items: [], isLoading: false, queryKeys: [] });
     const { result } = renderHook(useApplicationCapabilities, { initialProps: {} });
 
     await waitFor(async () => {

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -23,7 +23,7 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
 
 export const useApplicationCapabilitySets = (checkedAppIdsMap) => {
   const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
-  const { items: capabilitySets, isLoading: isCapabilitySetsLoading } = useChunkedApplicationCapabilitySets(selectedAppIds);
+  const { items: capabilitySets, isLoading: isCapabilitySetsLoading, queryKeys = [] } = useChunkedApplicationCapabilitySets(selectedAppIds);
 
   const [selectedCapabilitySetsMap, setSelectedCapabilitySetsMap] = useState({});
   const roleCapabilitySetsListIds = extractSelectedIdsFromObject(selectedCapabilitySetsMap);
@@ -46,5 +46,6 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap) => {
     setSelectedCapabilitySetsMap,
     roleCapabilitySetsListIds,
     isLoading: isCapabilitySetsLoading,
+    queryKeys
   };
 };

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
@@ -31,7 +31,7 @@ describe('useApplicationCapabilitySets', () => {
   });
 
   it('should test if returning fields and methods are defined', () => {
-    useChunkedApplicationCapabilitySets.mockReset().mockReturnValue({ items: [], isLoading: false });
+    useChunkedApplicationCapabilitySets.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
     const { result } = renderHook(useApplicationCapabilitySets, { initialProps: { cap1: true } });
 
     expect(result.current.capabilitySets).toStrictEqual({ data: [], settings: [], procedural: [] });
@@ -39,6 +39,7 @@ describe('useApplicationCapabilitySets', () => {
     expect(result.current.selectedCapabilitySetsMap).toStrictEqual({});
     expect(result.current.setSelectedCapabilitySetsMap).toBeDefined();
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.isLoading).toStrictEqual([['key1', 'key2']]);
   });
   it('should set checkedAppIdsMap and call onSubmitSelectApplications', async () => {
     const items = [

--- a/lib/hooks/useCapabilities/useCapabilities.js
+++ b/lib/hooks/useCapabilities/useCapabilities.js
@@ -14,7 +14,7 @@ export const useCapabilities = () => {
   const installedApplications = Object.keys(stripes.discovery.applications);
   const [namespace] = useNamespace({ key: 'capabilities-list' });
 
-  const { items, isLoading } = useChunkedCQLFetch({
+  const { items, isLoading, queryKeys = [] } = useChunkedCQLFetch({
     endpoint: 'capabilities',
     ids: installedApplications,
     limit: CAPABILITIES_LIMIT,
@@ -30,6 +30,7 @@ export const useCapabilities = () => {
 
   return {
     capabilitiesList: items,
-    isLoading
+    isLoading,
+    queryKeys
   };
 };

--- a/lib/hooks/useCapabilities/useCapabilities.test.js
+++ b/lib/hooks/useCapabilities/useCapabilities.test.js
@@ -105,5 +105,6 @@ describe('useCapabilities', () => {
 
     expect(result.current.capabilitiesList).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.queryKeys).toStrictEqual([]);
   });
 });

--- a/lib/hooks/useCapabilitySets/useCapabilitySets.js
+++ b/lib/hooks/useCapabilitySets/useCapabilitySets.js
@@ -18,7 +18,7 @@ export const useCapabilitySets = () => {
   const installedApplications = Object.keys(stripes.discovery.applications);
   const [namespace] = useNamespace({ key: 'capability-sets-list' });
 
-  const { items, isLoading } = useChunkedCQLFetch({
+  const { items, isLoading, queryKeys = [] } = useChunkedCQLFetch({
     endpoint: 'capability-sets',
     ids: installedApplications,
     limit: CAPABILITIES_LIMIT,
@@ -34,6 +34,7 @@ export const useCapabilitySets = () => {
 
   return {
     capabilitySetsList: items,
-    isLoading
+    isLoading,
+    queryKeys
   };
 };

--- a/lib/hooks/useCapabilitySets/useCapabilitySets.test.js
+++ b/lib/hooks/useCapabilitySets/useCapabilitySets.test.js
@@ -112,5 +112,6 @@ describe('useCapabilitySets', () => {
 
     expect(result.current.capabilitySetsList).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.queryKeys).toStrictEqual([]);
   });
 });

--- a/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.js
+++ b/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.js
@@ -11,7 +11,7 @@ import {
 // make sure to chunk the request to avoid hitting limits.
 
 export const useChunkedApplicationCapabilities = (appIds) => {
-  const { items, isLoading } = useChunkedCQLFetch({
+  const { items, isLoading, queryKeys = [] } = useChunkedCQLFetch({
     endpoint: 'capabilities',
     ids: appIds,
     limit: CAPABILITIES_LIMIT,
@@ -23,5 +23,5 @@ export const useChunkedApplicationCapabilities = (appIds) => {
     STEP_SIZE: APPLICATIONS_STEP_SIZE,
   });
 
-  return { items, isLoading };
+  return { items, isLoading, queryKeys };
 };

--- a/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.test.js
+++ b/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.test.js
@@ -40,6 +40,7 @@ describe('useChunkedApplicationCapabilities', () => {
 
     expect(result.current.items).toEqual([]);
     expect(result.current.isLoading).toBe(true);
+    expect(result.current.queryKeys).toStrictEqual([]);
   });
 
   it('should call useChunkedCQLFetch with correct parameters when appIds is empty', () => {
@@ -48,6 +49,7 @@ describe('useChunkedApplicationCapabilities', () => {
     useChunkedCQLFetch.mockReturnValue({
       items: [],
       isLoading: false,
+      queryKeys:[['key1', 'key2']]
     });
 
     const { result } = renderHook(() => useChunkedApplicationCapabilities(mockAppIds));
@@ -66,6 +68,7 @@ describe('useChunkedApplicationCapabilities', () => {
 
     expect(result.current.items).toEqual([]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.queryKeys).toStrictEqual([['key1', 'key2']]);
   });
 
   it('should reduce data correctly using reduceFunction', () => {

--- a/lib/hooks/useChunkedApplicationCapabilitySets/useChunkedApplicationCapabilitySets.js
+++ b/lib/hooks/useChunkedApplicationCapabilitySets/useChunkedApplicationCapabilitySets.js
@@ -11,7 +11,7 @@ import {
 // make sure to chunk the request to avoid hitting limits.
 
 export const useChunkedApplicationCapabilitySets = (appIds) => {
-  const { items, isLoading } = useChunkedCQLFetch({
+  const { items, isLoading, queryKeys = [] } = useChunkedCQLFetch({
     endpoint: 'capability-sets',
     ids: appIds,
     limit: CAPABILITIES_LIMIT,
@@ -23,5 +23,5 @@ export const useChunkedApplicationCapabilitySets = (appIds) => {
     STEP_SIZE: APPLICATIONS_STEP_SIZE,
   });
 
-  return { items, isLoading };
+  return { items, isLoading, queryKeys };
 };

--- a/lib/hooks/useChunkedApplicationCapabilitySets/useChunkedApplicationCapabilitySets.test.js
+++ b/lib/hooks/useChunkedApplicationCapabilitySets/useChunkedApplicationCapabilitySets.test.js
@@ -77,12 +77,13 @@ describe('useChunkedApplicationCapabilitySets', () => {
 
     useChunkedCQLFetch.mockImplementation(({ reduceFunction }) => {
       const items = reduceFunction(mockData);
-      return { items, isLoading: false };
+      return { items, isLoading: false, queryKeys:[['key1', 'key2']] };
     });
 
     const { result } = renderHook(() => useChunkedApplicationCapabilitySets(mockAppIds));
 
     expect(result.current.items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.queryKeys).toStrictEqual([['key1', 'key2']]);
   });
 });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-13](https://folio-org.atlassian.net/browse/UISAUTHCOM-13) - Cleanup only capabilities related queries on close edit role.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Use queryKeys field from useChunkedCQLFetch to invalidate query cache. 

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
