### PR TITLE
UISAUTHCOM-25: Update user capability hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 * [UISAUTHCOM-21](https://folio-org.atlassian.net/browse/UISAUTHCOM-21) ECS - Prevent editing of shared Policies from outside "Consortium manager".
 * [UISAUTHCOM-23](https://folio-org.atlassian.net/browse/UISAUTHCOM-23) Display toast message for saving and editing authorization roles.
 * [UISAUTHCOM-16](https://folio-org.atlassian.net/browse/UISAUTHCOM-16) Provide maxHeight to the capabilities tables.
+* [UISAUTHCOM-25](https://folio-org.atlassian.net/browse/UISAUTHCOM-25) Update user capability hooks.

--- a/lib/hooks/useUserCapabilities/useUserCapabilities.js
+++ b/lib/hooks/useUserCapabilities/useUserCapabilities.js
@@ -20,12 +20,11 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  *
  * @param {string} userId The user ID.
  * @param {string} tenant The Tenant ID. Passes into `useOkapiKy` which will default to `stripes.okapi.tenant` if omitted.
- * @param {string} roleId The Role ID
  * @param {boolean} expand Defines if capability sets must be expanded in the API response. Defaults to `false`.
  * @param {object} options Any additional options to pass into `useQuery()`.
  * @returns Capabilities.
  */
-export const useUserCapabilities = (userId, tenant = '', roleId, expand = false, options = {}) => {
+export const useUserCapabilities = (userId, tenant = '', expand = false, options = {}) => {
   const { enabled = true, ...otherOptions } = options;
   const stripes = useStripes();
   const installedApplications = Object.keys(stripes.discovery.applications);
@@ -33,13 +32,13 @@ export const useUserCapabilities = (userId, tenant = '', roleId, expand = false,
   const [namespace] = useNamespace({ key: 'user-capabilities-list' });
 
   const { data, isSuccess } = useQuery({
-    queryKey: [namespace, userId, expand, tenant, roleId],
+    queryKey: [namespace, userId, expand, tenant],
     queryFn: () => ky.get(
       `users/${userId}/capabilities`,
       {
         searchParams: {
           limit: CAPABILITIES_LIMIT,
-          query: roleId ? `cql.allRecords=1 sortby resource and roleId=${roleId}` : 'cql.allRecords=1 sortby resource',
+          query: 'cql.allRecords=1 sortby resource',
           expand: !!expand,
         },
       },

--- a/lib/hooks/useUserCapabilitiesSets/useUserCapabilitiesSets.js
+++ b/lib/hooks/useUserCapabilitiesSets/useUserCapabilitiesSets.js
@@ -20,11 +20,10 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  *
  * @param {string} userId The User ID.
  * @param {string} tenant The Tenant ID. Passes into `useOkapiKy` which will default to `stripes.okapi.tenant` if omitted.
- * @param {string} roleId The role ID
  * @param {object} options Any additional options to pass into `useQuery()`.
  * @returns Capability Sets.
  */
-export const useUserCapabilitiesSets = (userId, tenant, roleId, options = {}) => {
+export const useUserCapabilitiesSets = (userId, tenant, options = {}) => {
   const { enabled = true, ...otherOptions } = options;
   const stripes = useStripes();
   const installedApplications = Object.keys(stripes.discovery.applications);
@@ -32,16 +31,9 @@ export const useUserCapabilitiesSets = (userId, tenant, roleId, options = {}) =>
   const [namespace] = useNamespace({ key: 'role-capability-sets' });
 
   const { data, isSuccess } = useQuery({
-    queryKey: [namespace, userId, roleId],
+    queryKey: [namespace, userId],
     queryFn: () => {
-      const searchParams = roleId ? {
-        limit: CAPABILITIES_LIMIT,
-        query: `roleId=${roleId}`
-      }
-        :
-        {
-          limit: CAPABILITIES_LIMIT,
-        };
+      const searchParams = { limit: CAPABILITIES_LIMIT };
       return ky.get(`users/${userId}/capability-sets`, { searchParams }).json();
     },
     enabled: Boolean(enabled && !!userId),


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UISAUTHCOM-25

Here we remove `roleId` param from `useUserCapabilities` and `useUserCapabilitiesSets` since it's a useless param, endpoints fetching only direct assigned roles to the user.