### PR TITLE
UISAUTHCOM-24 Hide edit and share actions for policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 * [UISAUTHCOM-23](https://folio-org.atlassian.net/browse/UISAUTHCOM-23) Display toast message for saving and editing authorization roles.
 * [UISAUTHCOM-16](https://folio-org.atlassian.net/browse/UISAUTHCOM-16) Provide maxHeight to the capabilities tables.
 * [UISAUTHCOM-25](https://folio-org.atlassian.net/browse/UISAUTHCOM-25) Update user capability hooks.
+* [UISAUTHCOM-24](https://folio-org.atlassian.net/browse/UISAUTHCOM-24) Hide "edit" and "share" actions for policies.

--- a/lib/PolicyDetails/PolicyDetails/PolicyDetails.js
+++ b/lib/PolicyDetails/PolicyDetails/PolicyDetails.js
@@ -41,6 +41,12 @@ import {
 
 import css from '../style.css';
 
+/*
+  Create, edit, share should be disabled for the current release.
+  https://folio-org.atlassian.net/browse/UISAUTHCOM-24
+ */
+const IS_MUTATIONS_ENABLED = false;
+
 const PolicyDetails = ({
   policy,
   onClose,
@@ -70,7 +76,7 @@ const PolicyDetails = ({
       || !isTargetTenantCentral
       || isPolicyShared
     );
-    const isActionMenuHidden = isMutationsPrevented && isSharingPrevented;
+    const isActionMenuHidden = (isMutationsPrevented && isSharingPrevented) || !IS_MUTATIONS_ENABLED;
 
     if (isActionMenuHidden) return null;
 

--- a/lib/PolicyDetails/PolicyDetails/PolicyDetails.test.js
+++ b/lib/PolicyDetails/PolicyDetails/PolicyDetails.test.js
@@ -72,7 +72,7 @@ describe('PolicyDetails component', () => {
   });
 
   describe('ECS mode', () => {
-    it('should handle policy sharing when "Share to all" action is performed', async () => {
+    xit('should handle policy sharing when "Share to all" action is performed', async () => {
       isTenantConsortiumCentral.mockReturnValue(true);
 
       renderComponent({ displayShareAction: true });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISAUTHCOM-24

We need to hide the ability to create/edit/share authorization policy in the Consortium manager, until this functionality will be implemented in the Settings page. So this functionality will be disabled for Ramsons and should be enabled again in the Sunflower release.
