### PR TITLE
UISAUTHCOM-28: invalidate queries for capabilities, capabilitySets on RoleCreate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,4 +29,5 @@
 * [UISAUTHCOM-16](https://folio-org.atlassian.net/browse/UISAUTHCOM-16) Provide maxHeight to the capabilities tables.
 * [UISAUTHCOM-25](https://folio-org.atlassian.net/browse/UISAUTHCOM-25) Update user capability hooks.
 * [UISAUTHCOM-24](https://folio-org.atlassian.net/browse/UISAUTHCOM-24) Hide "edit" and "share" actions for policies.
-* [UISAUTHCOM-27](https://folio-org.atlassian.net/browse/UISAUTHCOM-27) - fix premature confirmation dialog appearance by putting Loading, MCL, ConfirmationDialog into accordion body.
+* [UISAUTHCOM-27](https://folio-org.atlassian.net/browse/UISAUTHCOM-27) - Fix premature confirmation dialog appearance by putting Loading, MCL, ConfirmationDialog into accordion body.
+* [UISAUTHCOM-28](https://folio-org.atlassian.net/browse/UISAUTHCOM-28) - Cleanup capabilities/sets data from query cache on RoleCreate.

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useHistory } from 'react-router';
 import { isEmpty } from 'lodash';
 
+import { useQueryClient } from 'react-query';
 import { MUTATION_ACTION_TYPE } from '../../constants';
 import {
   useApplicationCapabilities,
@@ -19,7 +20,7 @@ export const RoleCreate = ({
 }) => {
   const history = useHistory();
   const showCallout = useShowCallout();
-
+  const queryClient = useQueryClient();
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
@@ -31,6 +32,7 @@ export const RoleCreate = ({
     setSelectedCapabilitiesMap,
     roleCapabilitiesListIds,
     isLoading: isAppCapabilitiesLoading,
+    queryKeys: applicationCapabilitiesQueryKeys
   } = useApplicationCapabilities(checkedAppIdsMap, { tenantId });
 
   const {
@@ -40,6 +42,7 @@ export const RoleCreate = ({
     roleCapabilitySetsListIds,
     capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading,
+    queryKeys: applicationCapabilitySetsQueryKeys
   } = useApplicationCapabilitySets(checkedAppIdsMap, { tenantId });
 
   const { handleError } = useRoleMutationErrorHandler();
@@ -73,14 +76,22 @@ export const RoleCreate = ({
     { tenantId },
   );
 
-  const onClose = () => history.push(path);
+  const cleanupQueries = () => {
+    queryClient.removeQueries({ queryKey: applicationCapabilitiesQueryKeys.flat() });
+    queryClient.removeQueries({ queryKey: applicationCapabilitySetsQueryKeys.flat() });
+  };
+
+  const onClose = () => {
+    cleanupQueries();
+    history.push(path);
+  };
 
   const onSubmit = async (e) => {
     e.preventDefault();
 
     try {
       const { id: roleId } = await mutateRole({ name: roleName, description });
-
+      cleanupQueries();
       history.push(`${path}/${roleId}`);
       showCallout({ messageId: 'stripes-authorization-components.role.create.success' });
     } catch (error) {

--- a/lib/Role/RoleCreate/RoleCreate.test.js
+++ b/lib/Role/RoleCreate/RoleCreate.test.js
@@ -19,6 +19,15 @@ jest.mock('../../hooks', () => ({
   useCapabilities: jest.fn(),
 }));
 
+const mockRemoveQueries = jest.fn();
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useQueryClient: jest.fn(() => ({
+    clear: jest.fn(),
+    removeQueries: mockRemoveQueries
+  }))
+}));
+
 jest.mock('@folio/stripes/components', () => {
   const original = jest.requireActual('@folio/stripes/components');
   return {
@@ -65,6 +74,7 @@ describe('RoleCreate', () => {
       selectedCapabilitiesMap: {},
       setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
       isLoading: false,
+      queryKeys: ['capabilities', ['app-platform-complete-0.0.5']]
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -91,6 +101,7 @@ describe('RoleCreate', () => {
       selectedCapabilitySetsMap: {},
       setSelectedCapabilitySetsMap: jest.fn(),
       isLoading: false,
+      queryKeys: ['capabilitySets', ['app-platform-complete-0.0.5']]
     });
   });
 
@@ -115,21 +126,42 @@ describe('RoleCreate', () => {
     expect(descriptionInput).toHaveValue('Description');
   });
 
-  it('actions on click footer buttons', async () => {
-    const { getByTestId, getByRole } = renderComponent();
+  describe('actions on click footer buttons', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+    it('submit button', async () => {
+      const { getByTestId, getByRole } = renderComponent();
 
-    const submitButton = getByRole('button', { name: 'stripes-components.saveAndClose' });
-    const cancelButton = getByRole('button', { name: 'stripes-authorization-components.crud.cancel' });
+      const submitButton = getByRole('button', { name: 'stripes-components.saveAndClose' });
+      const cancelButton = getByRole('button', { name: 'stripes-authorization-components.crud.cancel' });
 
-    expect(submitButton).toBeDisabled();
-    expect(cancelButton).toBeInTheDocument();
+      expect(submitButton).toBeDisabled();
+      expect(cancelButton).toBeInTheDocument();
 
-    await act(async () => {
-      await userEvent.type(getByTestId('rolename-input'), 'New Role');
-      await userEvent.click(submitButton);
+      await act(async () => {
+        await userEvent.type(getByTestId('rolename-input'), 'New Role');
+        await userEvent.click(submitButton);
+      });
+
+      expect(mockMutateRole).toHaveBeenCalledWith({ name: 'New Role', description: '' });
+      expect(mockRemoveQueries).toHaveBeenCalledTimes(2);
+      expect(mockRemoveQueries).toHaveBeenNthCalledWith(1, { queryKey: ['capabilities', 'app-platform-complete-0.0.5'] });
+      expect(mockRemoveQueries).toHaveBeenNthCalledWith(2, { queryKey:['capabilitySets', 'app-platform-complete-0.0.5'] });
     });
 
-    expect(mockMutateRole).toHaveBeenCalledWith({ name: 'New Role', description: '' });
+    it('cancel button', async () => {
+      const { getByRole } = renderComponent();
+      const cancelButton = getByRole('button', { name: 'stripes-authorization-components.crud.cancel' });
+      expect(cancelButton).toBeInTheDocument();
+
+      await act(async () => {
+        await userEvent.click(cancelButton);
+      });
+      expect(mockRemoveQueries).toHaveBeenCalledTimes(2);
+      expect(mockRemoveQueries).toHaveBeenNthCalledWith(1, { queryKey: ['capabilities', 'app-platform-complete-0.0.5'] });
+      expect(mockRemoveQueries).toHaveBeenNthCalledWith(2, { queryKey: ['capabilitySets', 'app-platform-complete-0.0.5'] });
+    });
   });
 
   it('should call capability checkbox handler actions on click', async () => {

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -141,8 +141,13 @@ export const RoleEdit = ({ path, tenantId }) => {
     }
   }, [isRoleDetailsLoaded, roleDetails]);
 
+  const cleanupQueries = () => {
+    queryClient.removeQueries({ queryKey: applicationCapabilitiesQueryKeys.flat() });
+    queryClient.removeQueries({ queryKey: applicationCapabilitySetsQueryKeys.flat() });
+  };
+
   const onClose = () => {
-    queryClient.removeQueries({ queryKey: [...applicationCapabilitiesQueryKeys, ...applicationCapabilitySetsQueryKeys] });
+    cleanupQueries();
     history.push(`${path}/${roleId}`);
   };
 

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -156,7 +156,7 @@ describe('RoleEdit', () => {
       selectedCapabilitiesMap: { '5c5198f9-de27-4349-9537-dc0b2b41c8c3': true },
       setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
       isLoading: false,
-      queryKeys: []
+      queryKeys: ['core', ['app-platform-complete-0.0.5']]
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -224,7 +224,9 @@ describe('RoleEdit', () => {
     expect(submitButton).toBeEnabled();
 
     await userEvent.click(cancelButton);
-    expect(mockRemoveQueries).toHaveBeenCalledWith({ 'queryKey': [['app-platform-complete-0.0.5']] });
+    expect(mockRemoveQueries).toHaveBeenCalledTimes(2);
+    expect(mockRemoveQueries).toHaveBeenNthCalledWith(1, { 'queryKey': ['core', 'app-platform-complete-0.0.5'] });
+    expect(mockRemoveQueries).toHaveBeenNthCalledWith(2, { 'queryKey': ['app-platform-complete-0.0.5'] });
   });
 
   it('onSubmit invalidates "ui-authorization-roles" query and calls goBack on success', async () => {


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-28](https://folio-org.atlassian.net/browse/UISAUTHCOM-28) - "Capability sets" accordion has no loading animation when opening role for edit after creation
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
 PR also includes fixes for correctly cleaning up the queries from cache in RoleEdit.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
