### PR TITLE
[UISAUTHCOM-39] Enforce new "manage" permission set 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UISAUTHCOM-36](https://folio-org.atlassian.net/browse/UISAUTHCOM-36) Avoid extra capability requests for role sharing when not in central tenant
 * [UISAUTHCOM-37](https://folio-org.atlassian.net/browse/UISAUTHCOM-37) ECS - Add Tenant identifier to title of Select user modal.
 * [UISAUTHCOM-38](https://folio-org.atlassian.net/browse/UISAUTHCOM-38) Include "create" and "delete" actions in "settings" capability/capabilitySet accordions
+* [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "manage" permission set.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [UISAUTHCOM-36](https://folio-org.atlassian.net/browse/UISAUTHCOM-36) Avoid extra capability requests for role sharing when not in central tenant
 * [UISAUTHCOM-37](https://folio-org.atlassian.net/browse/UISAUTHCOM-37) ECS - Add Tenant identifier to title of Select user modal.
 * [UISAUTHCOM-38](https://folio-org.atlassian.net/browse/UISAUTHCOM-38) Include "create" and "delete" actions in "settings" capability/capabilitySet accordions
-* [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "manage" permission set.
+* [UISAUTHCOM-39](https://folio-org.atlassian.net/browse/UISAUTHCOM-39) Enforce new "manage" permission set and hide action menu if no actions are available.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/lib/RoleDetails/RoleDetails.js
+++ b/lib/RoleDetails/RoleDetails.js
@@ -106,21 +106,23 @@ export const RoleDetails = ({
       || !isTargetTenantCentral
       || isRoleShared
     );
-    const isActionMenuHidden = isMutationsPrevented && isSharingPrevented;
+
+    const isEditAllowed = isRoleShared ? stripes.hasPerm('consortia.sharing-roles-all.item.post') : stripes.hasPerm('roles.item.put');
+    const isCreateAllowed = stripes.hasPerm('roles.item.post');
+    const isDeleteAllowed = isRoleShared ? stripes.hasPerm('consortia.sharing-roles-all.item.delete') : stripes.hasPerm('roles.item.delete');
+    const isActionMenuHidden = (isMutationsPrevented && isSharingPrevented) || (!isEditAllowed && !isCreateAllowed && !isDeleteAllowed);
 
     if (isActionMenuHidden) return null;
 
     return (
       (
         <>
-          {!isMutationsPrevented && (
-            <IfPermission perm={isRoleShared ? 'consortia.sharing-roles-all.item.post' : 'roles.item.put'}>
-              <Button buttonStyle="dropdownItem" onClick={() => history.push(`${path}/${roleId}/edit`)}>
-                <Icon icon="edit">
-                  <FormattedMessage id="stripes-authorization-components.crud.edit" />
-                </Icon>
-              </Button>
-            </IfPermission>
+          {!isMutationsPrevented && isEditAllowed && (
+            <Button buttonStyle="dropdownItem" onClick={() => history.push(`${path}/${roleId}/edit`)}>
+              <Icon icon="edit">
+                <FormattedMessage id="stripes-authorization-components.crud.edit" />
+              </Icon>
+            </Button>
           )}
 
           {!isSharingPrevented && (
@@ -137,32 +139,28 @@ export const RoleDetails = ({
             </Button>
           )}
 
-          {!isMutationsPrevented && (
-            <IfPermission perm="roles.item.post">
-              <Button
-                buttonStyle="dropdownItem"
-                onClick={() => setIsDuplicating(true)}
-              >
-                <Icon size="small" icon="duplicate">
-                  <FormattedMessage id="stripes-authorization-components.crud.duplicate" />
-                </Icon>
-              </Button>
-            </IfPermission>
+          {!isMutationsPrevented && isCreateAllowed && (
+            <Button
+              buttonStyle="dropdownItem"
+              onClick={() => setIsDuplicating(true)}
+            >
+              <Icon size="small" icon="duplicate">
+                <FormattedMessage id="stripes-authorization-components.crud.duplicate" />
+              </Icon>
+            </Button>
           )}
 
-          {!isMutationsPrevented && (
-            <IfPermission perm={isRoleShared ? 'consortia.sharing-roles-all.item.delete' : 'roles.item.delete'}>
-              <Button
-                buttonStyle="dropdownItem"
-                onClick={() => {
-                  setIsDeleting(true);
-                }}
-              >
-                <Icon icon="trash">
-                  <FormattedMessage id="stripes-authorization-components.crud.delete" />
-                </Icon>
-              </Button>
-            </IfPermission>
+          {!isMutationsPrevented && isDeleteAllowed && (
+            <Button
+              buttonStyle="dropdownItem"
+              onClick={() => {
+                setIsDeleting(true);
+              }}
+            >
+              <Icon icon="trash">
+                <FormattedMessage id="stripes-authorization-components.crud.delete" />
+              </Icon>
+            </Button>
           )}
         </>
       )
@@ -227,10 +225,12 @@ export const RoleDetails = ({
             tenantId={tenantId}
             roleId={roleId}
           />
-          <RoleDetailsUsersAccordion
-            tenantId={tenantId}
-            roleId={roleId}
-          />
+          <IfPermission perm="ui-authorization-roles.users.settings.view">
+            <RoleDetailsUsersAccordion
+              tenantId={tenantId}
+              roleId={roleId}
+            />
+          </IfPermission>
         </AccordionSet>
       </AccordionStatus>
 


### PR DESCRIPTION
- Fulfills [UISAUTHCOM-39](https://folio-org.atlassian.net/browse/UISAUTHCOM-39).
- Only show the "Assigned users" accordion in the role details pane if user has `ui-authorization-roles.users.settings.view` perm. See dependent perm changes here: https://github.com/folio-org/ui-authorization-roles/pull/90
- Also, prevent Action menu from displaying if there are no actions to perform due to user not having sufficient perms.