### PR TITLE
UISAUTHCOM-41: Fix capabilities included in capability set are not deselected when deselecting a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [UISAUTHCOM-37](https://folio-org.atlassian.net/browse/UISAUTHCOM-37) ECS - Add Tenant identifier to title of Select user modal.
 * [UISAUTHCOM-38](https://folio-org.atlassian.net/browse/UISAUTHCOM-38) Include "create" and "delete" actions in "settings" capability/capabilitySet accordions
 * [UISAUTHCOM-39](https://folio-org.atlassian.net/browse/UISAUTHCOM-39) Enforce new "manage" permission set and hide action menu if no actions are available.
+* [UISAUTHCOM-40](https://folio-org.atlassian.net/browse/UISAUTHCOM-40) Add ability to select entire columns of capabilities in each capability/capabilitySet grid/accordion.
+* [UISAUTHCOM-41](https://folio-org.atlassian.net/browse/UISAUTHCOM-41) Fix disabled the issue with capabilities included in capability set are not deselected when deselecting a set.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/lib/Capabilities/constants.js
+++ b/lib/Capabilities/constants.js
@@ -46,7 +46,7 @@ export const columnWidths = {
   procedural: {
     [CAPABILITIES_COLUMN_NAMES.application]: '40%',
     [CAPABILITIES_COLUMN_NAMES.resource]: '48%',
-    [CAPABILITIES_COLUMN_NAMES.execute]: '6%',
+    [CAPABILITIES_COLUMN_NAMES.execute]: '9%',
   }
 };
 

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -65,10 +65,10 @@ export function getCheckboxHandlers({
       });
       setDisabledCapabilities(newDisabledCapabilities);
     } else {
-      const newDisabledCapabilities = { };
+      const newDisabledCapabilities = { ...disabledCapabilities };
       delete newSelectedCapabilitySetsMap[capabilitySetId];
       capSetCapabilities.forEach((cap) => {
-        newDisabledCapabilities[cap] = true;
+        delete newDisabledCapabilities[cap];
       });
       setDisabledCapabilities(newDisabledCapabilities);
     }

--- a/lib/Role/utils.test.js
+++ b/lib/Role/utils.test.js
@@ -35,7 +35,7 @@ describe('useCheckboxHandlers', () => {
       settings:{},
       procedural:{}
     };
-    disabledCapabilities = {};
+    disabledCapabilities = { 'cap1': true, 'cap15': true, 'cap16':true };
     actionCapabilitySets = {
       data: {
         view: ['b7cbae7f-5d7a-4af5-bd4e-f70ad245ba2c'],
@@ -81,7 +81,7 @@ describe('useCheckboxHandlers', () => {
     expect(setSelectedCapabilitiesMap).toHaveBeenCalledWith({});
   });
 
-  it('onChangeCapabilityCheckbox should call selectedCapabilitySetsMap when checked is TRUE ', () => {
+  it('onChangeCapabilitySetCheckbox should call selectedCapabilitySetsMap when checked is TRUE ', () => {
     const { onChangeCapabilitySetCheckbox } = getCheckboxHandlers({
       selectedCapabilitiesMap,
       setSelectedCapabilitiesMap,
@@ -100,9 +100,10 @@ describe('useCheckboxHandlers', () => {
     );
 
     expect(setSelectedCapabilitySetsMap).toHaveBeenCalledWith({ 'b7cbae7f-5d7a-4af5-bd4e-f70ad245ba2c':true });
+    expect(setDisabledCapabilities).toHaveBeenCalledWith({ cap1: true, cap15: true, cap16:true });
   });
 
-  it('onChangeCapabilityCheckbox should call selectedCapabilitySetsMap when checked is FALSE ', () => {
+  it('onChangeCapabilitySetCheckbox should call selectedCapabilitySetsMap when checked is FALSE ', () => {
     const { onChangeCapabilitySetCheckbox } = getCheckboxHandlers({
       selectedCapabilitiesMap,
       setSelectedCapabilitiesMap,
@@ -121,6 +122,7 @@ describe('useCheckboxHandlers', () => {
     );
 
     expect(setSelectedCapabilitySetsMap).toHaveBeenCalledWith({});
+    expect(setDisabledCapabilities).toHaveBeenCalledWith({ 'cap15': true, 'cap16': true });
   });
 
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-41](https://folio-org.atlassian.net/browse/UISAUTHCOM-41) - Capabilities included in capability set are not deselected when deselecting a set
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
