### PR TITLE
[UISAUTHCOM-42] Disable hyperlinks for user names in role details page if user doesn't have access to Users module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UISAUTHCOM-39](https://folio-org.atlassian.net/browse/UISAUTHCOM-39) Enforce new "manage" permission set and hide action menu if no actions are available.
 * [UISAUTHCOM-40](https://folio-org.atlassian.net/browse/UISAUTHCOM-40) Add ability to select entire columns of capabilities in each capability/capabilitySet grid/accordion.
 * [UISAUTHCOM-41](https://folio-org.atlassian.net/browse/UISAUTHCOM-41) Fix disabled the issue with capabilities included in capability set are not deselected when deselecting a set.
+* [UISAUTHCOM-42](https://folio-org.atlassian.net/browse/UISAUTHCOM-42) Disable hyperlinks for user names in role details page if user doesn't have access to Users module.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.js
+++ b/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.js
@@ -1,5 +1,7 @@
 import keyBy from 'lodash/keyBy';
 import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Accordion,
@@ -10,12 +12,9 @@ import {
   TextLink,
   ConfirmationModal,
 } from '@folio/stripes/components';
-
-import { FormattedMessage, useIntl } from 'react-intl';
-
+import { stripes } from '@folio/stripes/core';
 import { getFullName } from '@folio/stripes/util';
 
-import { useMemo } from 'react';
 import {
   useUserGroups,
   useAssignUsersFlow, useUsersByRoleId
@@ -23,6 +22,7 @@ import {
 import { RoleDetailsAssignUsers } from '../RoleDetailsAssignUsers/RoleDetailsAssignUsers';
 
 export const RoleDetailsUsersAccordion = ({ roleId, tenantId }) => {
+  const stripes = useStripes();
   const { formatMessage } = useIntl();
 
   const { users, isLoading: usersIsLoading, refetch } = useUsersByRoleId(roleId, { tenantId });
@@ -46,10 +46,14 @@ export const RoleDetailsUsersAccordion = ({ roleId, tenantId }) => {
   });
 
   const usersData = sortedUsers.map(i => {
-    const fullName = (
+    const fullName = stripes.hasPerm('ui-users.view') ? (
       <TextLink to={`/users/preview/${i.id}?query=${i.username}`}>
         {getFullName(i)}
       </TextLink>
+    ) : (
+      <span>
+        {getFullName(i)}
+      </span>
     );
 
     const patronGroup = groupHash[i.patronGroup]?.group || <NoValue />;

--- a/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.js
+++ b/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.js
@@ -12,7 +12,7 @@ import {
   TextLink,
   ConfirmationModal,
 } from '@folio/stripes/components';
-import { stripes } from '@folio/stripes/core';
+import { useStripes } from '@folio/stripes/core';
 import { getFullName } from '@folio/stripes/util';
 
 import {

--- a/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.test.js
+++ b/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.test.js
@@ -8,6 +8,12 @@ import {
 } from '../../hooks';
 import { RoleDetailsUsersAccordion } from './RoleDetailsUsersAccordion';
 
+const mockHasPerm = jest.fn();
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useStripes: () => ({ hasPerm: mockHasPerm }),
+}));
 jest.mock('../RoleDetailsAssignUsers');
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
@@ -58,6 +64,9 @@ const renderComponent = () => render(
 );
 
 describe('RoleDetailsUsersAccordion', () => {
+  beforeEach(() => {
+    mockHasPerm.mockReturnValue(true);
+  });
   afterAll(() => {
     jest.clearAllMocks();
   });
@@ -76,11 +85,32 @@ describe('RoleDetailsUsersAccordion', () => {
     });
   });
 
+  // describe('when ui-users.view perm is absent', () => {
+  //   mockHasPerm.mockReturnValue(false);
+  //   useUsersByRoleId.mockReturnValue({ users, isLoading: false });
+  //   useUserGroups.mockReturnValue({ userGroups, isLoading: false });
+  //   const { getByText } = renderComponent();
+
+  //   it('doesn`\t include hyperlinks on user names', () => {
+  //     expect(getByText('stripes-authorization-components.assignedUsers')).not.toContainHTML('a');
+  //   });
+  // });
+
   it('render loading spinner', () => {
     useUsersByRoleId.mockReturnValue({ isLoading: true, users: [] });
 
     const { getByText } = renderComponent();
 
     getByText('Loading');
+  });
+
+  it('doesn`\t include hyperlinks on user names when ui-users.view perm is absent', () => {
+    mockHasPerm.mockReturnValue(false);
+    useUsersByRoleId.mockReturnValue({ users, isLoading: false });
+    useUserGroups.mockReturnValue({ userGroups, isLoading: false });
+
+    const { getByText } = renderComponent();
+    getByText('stripes-authorization-components.assignedUsers');
+    expect(getByText(users[0].personal.firstName, { exact: false })).toContainHTML('span');
   });
 });

--- a/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.test.js
+++ b/lib/RoleDetails/RoleDetailsUsersAccordion/RoleDetailsUsersAccordion.test.js
@@ -85,17 +85,6 @@ describe('RoleDetailsUsersAccordion', () => {
     });
   });
 
-  // describe('when ui-users.view perm is absent', () => {
-  //   mockHasPerm.mockReturnValue(false);
-  //   useUsersByRoleId.mockReturnValue({ users, isLoading: false });
-  //   useUserGroups.mockReturnValue({ userGroups, isLoading: false });
-  //   const { getByText } = renderComponent();
-
-  //   it('doesn`\t include hyperlinks on user names', () => {
-  //     expect(getByText('stripes-authorization-components.assignedUsers')).not.toContainHTML('a');
-  //   });
-  // });
-
   it('render loading spinner', () => {
     useUsersByRoleId.mockReturnValue({ isLoading: true, users: [] });
 


### PR DESCRIPTION
- Fixes [UISAUTHCOM-42](https://folio-org.atlassian.net/browse/UISAUTHCOM-42) 
- If user has `ui-users.view` perm, wrap user names in `<TextLink>` which links to that user in the Users module. Otherwise, wrap in `<span>`.