### PR TITLE
UISAUTHCOM-43: Fix capabilities from unselected application sometimes shown as assigned for a role after editing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UISAUTHCOM-39](https://folio-org.atlassian.net/browse/UISAUTHCOM-39) Enforce new "manage" permission set and hide action menu if no actions are available.
 * [UISAUTHCOM-40](https://folio-org.atlassian.net/browse/UISAUTHCOM-40) Add ability to select entire columns of capabilities in each capability/capabilitySet grid/accordion.
 * [UISAUTHCOM-41](https://folio-org.atlassian.net/browse/UISAUTHCOM-41) Fix disabled the issue with capabilities included in capability set are not deselected when deselecting a set.
+* [UISAUTHCOM-43](https://folio-org.atlassian.net/browse/UISAUTHCOM-43) Fix capabilities from unselected application sometimes shown as assigned for a role after editing.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useHistory } from 'react-router';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { useQueryClient } from 'react-query';
 import { MUTATION_ACTION_TYPE } from '../../constants';
@@ -35,7 +35,9 @@ export const RoleCreate = ({
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilities({ checkedAppIdsMap,
+    options:{ tenantId },
+    setDisabledCapabilities });
 
   const {
     capabilitySets,

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -1,4 +1,5 @@
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
@@ -60,7 +61,9 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilities({ checkedAppIdsMap,
+    options: { tenantId },
+    setDisabledCapabilities });
 
   const {
     capabilitySets,
@@ -72,7 +75,8 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
     actionCapabilitySets
-  } = useApplicationCapabilitySets(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilitySets({ checkedAppIdsMap,
+    options: { tenantId } });
 
   const unselectAllCapabilitiesAndSets = () => {
     setSelectedCapabilitiesMap({});
@@ -180,7 +184,7 @@ export const RoleEdit = ({ path, tenantId }) => {
       onClose();
       showCallout({ messageId: 'stripes-authorization-components.role.edit.success' });
     } catch (error) {
-      handleError(MUTATION_ACTION_TYPE.update, error);
+      await handleError(MUTATION_ACTION_TYPE.update, error);
     }
   };
 

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -91,6 +91,24 @@ export const useApplicationCapabilities = ({
     [capabilities],
   );
 
+  /*
+    What happens in useEffect?
+    Our useApplicationCapabilities hook receives a list of the selected applications as argument,
+    and we retrieve the capabilities ONLY for the selected applications.
+    The user will then be able to select from the provided capabilities.
+    useEffect handles the situation where the user changes the selected applications, causing new capabilities to be retrieved.
+    However, previously selected capabilities may no longer be present in the new list of selected application capabilities.
+    It filters them by checking whether the selected capability set is included in the new list of capabilities.
+    It iterates over selectedCapabilitiesMap, disabledCapabilities, and if any of them are not in the new list of capabilitySets,
+    they are removed.
+    Example,
+      const selectedCapabilitiesMap = { id1: true, id2: true },
+            disabledCapabilities = { id3: true }
+            checkedAppCaps = { id1: true };
+     1. Since checkedAppCaps does not include id2, it is removed from selectedCapabilitiesMap.
+     2. Since checkedAppCaps does not include id3, it is removed from disabledCapabilities
+   */
+
   useEffect(() => {
     if (!isCapabilitiesLoading && !isEmpty(checkedAppCaps)) {
       setSelectedCapabilitiesMap(removeUncheckedCaps(checkedAppCaps));

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -5,10 +5,10 @@ import {
   useState,
 } from 'react';
 
+import isEmpty from 'lodash/isEmpty';
 import {
   extractSelectedIdsFromObject,
   getCapabilitiesGroupedByTypeAndResource,
-  getOnlyIntersectedWithApplicationsCapabilities,
 } from '../../utils';
 import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapabilities';
 
@@ -48,15 +48,6 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
       .filter(Boolean);
   }, [capabilities, roleCapabilitiesListIds]);
 
-  useEffect(() => {
-    if (!isCapabilitiesLoading) {
-      const updatedSelectedCapabilitiesMap = getOnlyIntersectedWithApplicationsCapabilities(capabilities, roleCapabilitiesListIds);
-      setSelectedCapabilitiesMap(updatedSelectedCapabilitiesMap);
-    }
-    // isCapabilitiesLoading only information we need to know if capabilities fetched
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCapabilitiesLoading]);
-
   const memoizedCapabilities = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilities), [capabilities]);
 
   const actionCapabilities = useMemo(() => {
@@ -69,6 +60,29 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
       return acc;
     }, initialStructure);
   }, [capabilities]);
+
+  const checkedAppCaps = useMemo(() => capabilities.reduce((acc, capSet) => {
+    acc[capSet.id] = true;
+    return acc;
+  }, {}), [capabilities]);
+
+  useEffect(() => {
+    if (!isCapabilitiesLoading && !isEmpty(checkedAppCaps)) {
+      setSelectedCapabilitiesMap((prevCapSets) => {
+        const copy = { ...prevCapSets };
+        let hasChanged = false;
+
+        for (const capSet in copy) {
+          if (!(capSet in checkedAppCaps)) {
+            delete copy[capSet];
+            hasChanged = true;
+          }
+        }
+
+        return hasChanged ? copy : prevCapSets;
+      });
+    }
+  }, [checkedAppCaps, isCapabilitiesLoading]);
 
   return {
     capabilities: memoizedCapabilities,

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -12,11 +12,29 @@ import {
 } from '../../utils';
 import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapabilities';
 
+function removeUncheckedCaps(checkedAppCaps) {
+  return (prevCaps) => {
+    const copy = { ...prevCaps };
+    let hasChanged = false;
+
+    for (const cap in copy) {
+      if (!(cap in checkedAppCaps)) {
+        delete copy[cap];
+        hasChanged = true;
+      }
+    }
+
+    return hasChanged ? copy : prevCaps;
+  };
+}
+
 /**
  * Custom hook that retrieves application capabilities based on the selected application IDs.
  *
  * @param {Object} checkedAppIdsMap - An object containing the selected application IDs. Using
  *   this object, the hook will retrieve the capabilities for the selected applications.
+ * @param {Object} options - query options.
+ * @param {Function} setDisabledCapabilities - disabled capabilities setter function.
  * @return {Object} An object containing the following properties:
  *   - capabilities: An object containing the capabilities grouped by type and resource.
  *   - selectedCapabilitiesMap: An object containing the selected capabilities mapped by their IDs.
@@ -27,7 +45,11 @@ import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapab
  *   - action capabilities: An object with capabilities based on capability type and action
  */
 
-export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
+export const useApplicationCapabilities = ({
+  checkedAppIdsMap,
+  options = {},
+  setDisabledCapabilities,
+}) => {
   const { tenantId } = options;
 
   const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
@@ -61,27 +83,21 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
     }, initialStructure);
   }, [capabilities]);
 
-  const checkedAppCaps = useMemo(() => capabilities.reduce((acc, capSet) => {
-    acc[capSet.id] = true;
-    return acc;
-  }, {}), [capabilities]);
+  const checkedAppCaps = useMemo(
+    () => capabilities.reduce((acc, capSet) => {
+      acc[capSet.id] = true;
+      return acc;
+    }, {}),
+    [capabilities],
+  );
 
   useEffect(() => {
     if (!isCapabilitiesLoading && !isEmpty(checkedAppCaps)) {
-      setSelectedCapabilitiesMap((prevCapSets) => {
-        const copy = { ...prevCapSets };
-        let hasChanged = false;
-
-        for (const capSet in copy) {
-          if (!(capSet in checkedAppCaps)) {
-            delete copy[capSet];
-            hasChanged = true;
-          }
-        }
-
-        return hasChanged ? copy : prevCapSets;
-      });
+      setSelectedCapabilitiesMap(removeUncheckedCaps(checkedAppCaps));
+      setDisabledCapabilities(removeUncheckedCaps(checkedAppCaps));
     }
+    // setDisabledCapabilities comes from outside, so we don't need to add it to the dependencies list
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checkedAppCaps, isCapabilitiesLoading]);
 
   return {
@@ -92,6 +108,6 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
     setSelectedCapabilitiesMap,
     isLoading: isCapabilitiesLoading,
     queryKeys,
-    actionCapabilities
+    actionCapabilities,
   };
 };

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
@@ -27,7 +27,10 @@ describe('useApplicationCapabilities', () => {
 
   it('should test if returning fields and methods are defined', () => {
     useChunkedApplicationCapabilities.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap: { cap1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
 
     expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
     expect(result.current.roleCapabilitiesListIds).toStrictEqual([]);
@@ -44,7 +47,10 @@ describe('useApplicationCapabilities', () => {
     ];
     useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items, isLoading: false });
 
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap:{ cap1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
 
     expect(result.current.capabilities).toStrictEqual({
       data:  [
@@ -72,7 +78,7 @@ describe('useApplicationCapabilities', () => {
 
   it('should set empty capabilities in the case of empty appIds', async () => {
     useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items: [], isLoading: false, queryKeys: [] });
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: {} });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: { checkedAppIdsMap: {} } });
 
     await waitFor(async () => {
       expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
@@ -78,11 +78,42 @@ describe('useApplicationCapabilities', () => {
 
   it('should set empty capabilities in the case of empty appIds', async () => {
     useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items: [], isLoading: false, queryKeys: [] });
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: { checkedAppIdsMap: {} } });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: { checkedAppIdsMap: {}, setDisabledCapabilities: jest.fn() } });
 
     await waitFor(async () => {
       expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
       expect(result.current.selectedCapabilitiesMap).toStrictEqual({});
     });
+  });
+
+  it('should remove unchecked capabilities from selectedCapabilitiesMap', async () => {
+    useChunkedApplicationCapabilities.mockClear().mockReturnValue({
+      items: [
+        { id: 1, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    const { result, rerender } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap: { app1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
+
+    await waitFor(() => {
+      result.current.setSelectedCapabilitiesMap({ 333: true, 222: true });
+    });
+
+    rerender({ checkedAppIdsMap:{ app2: true }, setDisabledCapabilities: jest.fn() });
+    expect(result.current.selectedCapabilitiesMap).toEqual({ 222:true, 333: true });
+
+    useChunkedApplicationCapabilities.mockClear().mockReturnValue({
+      items: [
+        { id: 222, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    rerender({ checkedAppIdsMap:{ app2:true }, setDisabledCapabilities: jest.fn() });
+    expect(result.current.selectedCapabilitiesMap).toEqual({ 222:true });
   });
 });

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -22,7 +22,7 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
  *   - isLoading: A boolean indicating whether capability sets are currently being fetched.
  */
 
-export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => {
+export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} }) => {
   const { tenantId } = options;
 
   const selectedAppIds = Object.keys(checkedAppIdsMap);
@@ -56,10 +56,13 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
     }, initialStructure);
   }, [capabilitySets]);
 
-  const checkedAppCapSets = useMemo(() => capabilitySets.reduce((acc, capSet) => {
-    acc[capSet.id] = true;
-    return acc;
-  }, {}), [capabilitySets]);
+  const checkedAppCapSets = useMemo(
+    () => capabilitySets.reduce((acc, capSet) => {
+      acc[capSet.id] = true;
+      return acc;
+    }, {}),
+    [capabilitySets],
+  );
 
   useEffect(() => {
     if (!isCapabilitySetsLoading && !isEmpty(checkedAppCapSets)) {
@@ -80,7 +83,7 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
   }, [checkedAppCapSets, isCapabilitySetsLoading]);
 
   return {
-    capabilitySets:memoizedCapabilitySets,
+    capabilitySets: memoizedCapabilitySets,
     capabilitySetsList: capabilitySets,
     selectedCapabilitySetsMap,
     setSelectedCapabilitySetsMap,
@@ -88,6 +91,6 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
     roleCapabilitySetsListNames,
     isLoading: isCapabilitySetsLoading,
     queryKeys,
-    actionCapabilitySets
+    actionCapabilitySets,
   };
 };

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -1,10 +1,9 @@
 import keyBy from 'lodash/keyBy';
 import { useEffect, useMemo, useState } from 'react';
 
+import isEmpty from 'lodash/isEmpty';
 import {
-  extractSelectedIdsFromObject,
   getCapabilitiesGroupedByTypeAndResource,
-  getOnlyIntersectedWithApplicationsCapabilities
 } from '../../utils';
 import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCapabilitySets';
 
@@ -26,7 +25,7 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
 export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => {
   const { tenantId } = options;
 
-  const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
+  const selectedAppIds = Object.keys(checkedAppIdsMap);
   const {
     items: capabilitySets,
     isLoading: isCapabilitySetsLoading,
@@ -34,7 +33,7 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
   } = useChunkedApplicationCapabilitySets(selectedAppIds, { tenantId });
 
   const [selectedCapabilitySetsMap, setSelectedCapabilitySetsMap] = useState({});
-  const roleCapabilitySetsListIds = extractSelectedIdsFromObject(selectedCapabilitySetsMap);
+  const roleCapabilitySetsListIds = Object.keys(selectedCapabilitySetsMap);
 
   const roleCapabilitySetsListNames = useMemo(() => {
     const capabilitySetsMap = keyBy(capabilitySets, 'id');
@@ -43,15 +42,6 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
       .map((capabilitySetId) => capabilitySetsMap[capabilitySetId]?.name)
       .filter(Boolean);
   }, [capabilitySets, roleCapabilitySetsListIds]);
-
-  useEffect(() => {
-    if (!isCapabilitySetsLoading) {
-      const updatedSelectedCapabilitySetsMap = getOnlyIntersectedWithApplicationsCapabilities(capabilitySets, roleCapabilitySetsListIds);
-      setSelectedCapabilitySetsMap(updatedSelectedCapabilitySetsMap);
-    }
-    // isCapabilitySetsLoading only information we need to know if capability sets fetched
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCapabilitySetsLoading]);
 
   const memoizedCapabilitySets = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilitySets), [capabilitySets]);
 
@@ -65,6 +55,29 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
       return acc;
     }, initialStructure);
   }, [capabilitySets]);
+
+  const checkedAppCapSets = useMemo(() => capabilitySets.reduce((acc, capSet) => {
+    acc[capSet.id] = true;
+    return acc;
+  }, {}), [capabilitySets]);
+
+  useEffect(() => {
+    if (!isCapabilitySetsLoading && !isEmpty(checkedAppCapSets)) {
+      setSelectedCapabilitySetsMap((prevCapSets) => {
+        const copy = { ...prevCapSets };
+        let hasChanged = false;
+
+        for (const capSet in copy) {
+          if (!(capSet in checkedAppCapSets)) {
+            delete copy[capSet];
+            hasChanged = true;
+          }
+        }
+
+        return hasChanged ? copy : prevCapSets;
+      });
+    }
+  }, [checkedAppCapSets, isCapabilitySetsLoading]);
 
   return {
     capabilitySets:memoizedCapabilitySets,

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -8,7 +8,7 @@ import {
 import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCapabilitySets';
 
 /**
- * Customhook that fetches and manages capability sets for a given list of checked application IDs.
+ * Custom hook that fetches and manages capability sets for a given list of checked application IDs.
  *
  * @param {Object} checkedAppIdsMap - An object mapping application IDs to boolean values indicating whether they are checked.
  *   Using this object, the hook will fetch the capability sets for the selected applications.
@@ -63,6 +63,21 @@ export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} })
     }, {}),
     [capabilitySets],
   );
+
+  /*
+    What happens in useEffect?
+    Our useApplicationCapabilitySets hook receives a list of the selected applications as argument,
+    and we retrieve the capability sets ONLY for the selected applications.
+    The user will then be able to select from the provided capabilitySets.
+    useEffect handles the situation where the user changes the selected applications, causing new capabilitySets to be retrieved.
+    However, previously selected capability sets may no longer be present in the new list of selected application capability sets.
+    It filters them by checking whether the selected capability set is included in the new list of capabilitySets.
+    It iterates over selectedCapabilitySets, and if any of them are not in the new list of capabilitySets, they are removed.
+    Example,
+      const selectedCapabilitiesMap = { id1: true, id2: true },
+            checkedAppCapSets = { id1: true };
+     Since checkedAppCapSets does not include id2, it is removed from selectedCapabilitySetsMap.
+   */
 
   useEffect(() => {
     if (!isCapabilitySetsLoading && !isEmpty(checkedAppCapSets)) {

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
@@ -90,4 +90,34 @@ describe('useApplicationCapabilitySets', () => {
       expect(result.current.selectedCapabilitySetsMap).toStrictEqual({});
     });
   });
+
+  it('should remove unchecked capability sets from selectedCapabilitySetsMap', async () => {
+    useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({
+      items: [
+        { id: 1, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    const { result, rerender } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { app1: true }
+    } });
+
+    await waitFor(() => {
+      result.current.setSelectedCapabilitySetsMap({ 333: true, 222: true });
+    });
+
+    rerender({ checkedAppIdsMap:{ app2: true } });
+    expect(result.current.selectedCapabilitySetsMap).toEqual({ 222:true, 333: true });
+
+    useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({
+      items: [
+        { id: 222, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    rerender({ checkedAppIdsMap:{ app2:true } });
+    expect(result.current.selectedCapabilitySetsMap).toEqual({ 222:true });
+  });
 });

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
@@ -32,7 +32,9 @@ describe('useApplicationCapabilitySets', () => {
 
   it('should test if returning fields and methods are defined', () => {
     useChunkedApplicationCapabilitySets.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     expect(result.current.capabilitySets).toStrictEqual({ data: [], settings: [], procedural: [] });
     expect(result.current.roleCapabilitySetsListIds).toStrictEqual([]);
@@ -49,7 +51,9 @@ describe('useApplicationCapabilitySets', () => {
     ];
     useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({ items, isLoading: false });
 
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     expect(result.current.capabilitySets).toStrictEqual({
       data:  [
@@ -77,7 +81,9 @@ describe('useApplicationCapabilitySets', () => {
 
   it('should set empty capabilities in the case of empty appIds', async () => {
     useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({ items: [], isLoading: false });
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {} });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     await waitFor(async () => {
       expect(result.current.capabilitySets).toStrictEqual({ data: [], settings: [], procedural: [] });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Refs [UISAUTHCOM-43](https://folio-org.atlassian.net/browse/UISAUTHCOM-43)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
 Changed hooks receives a list of the selected applications as argument,
    and we retrieve the capabilities ***ONLY*** for the selected applications.
    The user will then be able to select from the provided capabilities.
    ***useEffect*** handles the situation where the user changes the selected applications, causing new capabilities/sets to be retrieved.
    However, previously selected capabilities may no longer be present in the new list of selected application capabilities/sets.
    It filters them by checking whether the selected capability/set is included in the new list of capabilities/sets.
    It iterates over selectedCapabilitiesMap, disabledCapabilities, and if any of them are not in the new list of capabilities/sets,
    **they are removed**.
    Example,
      ```const selectedCapabilitiesMap = { id1: true, id2: true },
            disabledCapabilities = { id3: true },
            checkedAppCaps = { id1: true };```
     1. Since checkedAppCaps does not include id2, it is removed from selectedCapabilitiesMap.
     2. Since checkedAppCaps does not include id3, it is removed from disabledCapabilities

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
