### PR TITLE
UISAUTHCOM-43 hide capabilities from unselected application after editing roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UISAUTHCOM-36](https://folio-org.atlassian.net/browse/UISAUTHCOM-36) Avoid extra capability requests for role sharing when not in central tenant
 * [UISAUTHCOM-37](https://folio-org.atlassian.net/browse/UISAUTHCOM-37) ECS - Add Tenant identifier to title of Select user modal.
 * [UISAUTHCOM-38](https://folio-org.atlassian.net/browse/UISAUTHCOM-38) Include "create" and "delete" actions in "settings" capability/capabilitySet accordions
+* [UISAUTHCOM-43](https://folio-org.atlassian.net/browse/UISAUTHCOM-43) Fix capabilities from unselected application sometimes shown as assigned for a role after editing.
 
 ## [1.0.0](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.0) (2024-11-01)
 

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -47,7 +47,7 @@ export const RoleCreate = ({
     capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys
-  } = useApplicationCapabilitySets({ checkedAppIdsMap, options: { tenantId }});
+  } = useApplicationCapabilitySets({ checkedAppIdsMap, options: { tenantId } });
 
   const { handleError } = useRoleMutationErrorHandler();
 

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useHistory } from 'react-router';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { useQueryClient } from 'react-query';
 import { MUTATION_ACTION_TYPE } from '../../constants';
@@ -32,8 +32,12 @@ export const RoleCreate = ({
     setSelectedCapabilitiesMap,
     roleCapabilitiesListIds,
     isLoading: isAppCapabilitiesLoading,
-    queryKeys: applicationCapabilitiesQueryKeys
-  } = useApplicationCapabilities(checkedAppIdsMap, { tenantId });
+    queryKeys: applicationCapabilitiesQueryKeys,
+  } = useApplicationCapabilities({
+    checkedAppIdsMap,
+    options: { tenantId },
+    setDisabledCapabilities
+  });
 
   const {
     capabilitySets,
@@ -43,7 +47,7 @@ export const RoleCreate = ({
     capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys
-  } = useApplicationCapabilitySets(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilitySets({ checkedAppIdsMap, options: { tenantId }});
 
   const { handleError } = useRoleMutationErrorHandler();
 

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -1,4 +1,5 @@
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
@@ -58,7 +59,9 @@ export const RoleEdit = ({ path, tenantId }) => {
     roleCapabilitiesListNames,
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
-  } = useApplicationCapabilities(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilities({ checkedAppIdsMap,
+    options: { tenantId },
+    setDisabledCapabilities });
 
   const {
     capabilitySets,
@@ -69,7 +72,8 @@ export const RoleEdit = ({ path, tenantId }) => {
     capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
-  } = useApplicationCapabilitySets(checkedAppIdsMap, { tenantId });
+  } = useApplicationCapabilitySets({ checkedAppIdsMap,
+    options: { tenantId } });
 
   const unselectAllCapabilitiesAndSets = () => {
     setSelectedCapabilitiesMap({});
@@ -193,7 +197,7 @@ export const RoleEdit = ({ path, tenantId }) => {
       onClose();
       showCallout({ messageId: 'stripes-authorization-components.role.edit.success' });
     } catch (error) {
-      handleError(MUTATION_ACTION_TYPE.update, error);
+      await handleError(MUTATION_ACTION_TYPE.update, error);
     }
   };
 

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -5,18 +5,36 @@ import {
   useState,
 } from 'react';
 
+import isEmpty from 'lodash/isEmpty';
 import {
   extractSelectedIdsFromObject,
   getCapabilitiesGroupedByTypeAndResource,
-  getOnlyIntersectedWithApplicationsCapabilities,
 } from '../../utils';
 import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapabilities';
+
+function removeUncheckedCaps(checkedAppCaps) {
+  return (prevCaps) => {
+    const copy = { ...prevCaps };
+    let hasChanged = false;
+
+    for (const cap in copy) {
+      if (!(cap in checkedAppCaps)) {
+        delete copy[cap];
+        hasChanged = true;
+      }
+    }
+
+    return hasChanged ? copy : prevCaps;
+  };
+}
 
 /**
  * Custom hook that retrieves application capabilities based on the selected application IDs.
  *
  * @param {Object} checkedAppIdsMap - An object containing the selected application IDs. Using
  *   this object, the hook will retrieve the capabilities for the selected applications.
+ * @param {Object} options - query options.
+ * @param {Function} setDisabledCapabilities - disabled capabilities setter function.
  * @return {Object} An object containing the following properties:
  *   - capabilities: An object containing the capabilities grouped by type and resource.
  *   - selectedCapabilitiesMap: An object containing the selected capabilities mapped by their IDs.
@@ -25,7 +43,11 @@ import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapab
  *   - isLoading: A boolean indicating if the capabilities are currently being loaded.
  */
 
-export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
+export const useApplicationCapabilities = ({
+  checkedAppIdsMap,
+  options = {},
+  setDisabledCapabilities,
+}) => {
   const { tenantId } = options;
 
   const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
@@ -46,16 +68,42 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
       .filter(Boolean);
   }, [capabilities, roleCapabilitiesListIds]);
 
-  useEffect(() => {
-    if (!isCapabilitiesLoading) {
-      const updatedSelectedCapabilitiesMap = getOnlyIntersectedWithApplicationsCapabilities(capabilities, roleCapabilitiesListIds);
-      setSelectedCapabilitiesMap(updatedSelectedCapabilitiesMap);
-    }
-    // isCapabilitiesLoading only information we need to know if capabilities fetched
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCapabilitiesLoading]);
-
   const memoizedCapabilities = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilities), [capabilities]);
+
+  const checkedAppCaps = useMemo(
+    () => capabilities.reduce((acc, capSet) => {
+      acc[capSet.id] = true;
+      return acc;
+    }, {}),
+    [capabilities],
+  );
+
+  /*
+    What happens in useEffect?
+    Our useApplicationCapabilities hook receives a list of the selected applications as argument,
+    and we retrieve the capabilities ONLY for the selected applications.
+    The user will then be able to select from the provided capabilities.
+    useEffect handles the situation where the user changes the selected applications, causing new capabilities to be retrieved.
+    However, previously selected capabilities may no longer be present in the new list of selected application capabilities.
+    It filters them by checking whether the selected capability set is included in the new list of capabilities.
+    It iterates over selectedCapabilitiesMap, disabledCapabilities, and if any of them are not in the new list of capabilitySets,
+    they are removed.
+    Example,
+      const selectedCapabilitiesMap = { id1: true, id2: true },
+            disabledCapabilities = { id3: true }
+            checkedAppCaps = { id1: true };
+     1. Since checkedAppCaps does not include id2, it is removed from selectedCapabilitiesMap.
+     2. Since checkedAppCaps does not include id3, it is removed from disabledCapabilities
+   */
+
+  useEffect(() => {
+    if (!isCapabilitiesLoading && !isEmpty(checkedAppCaps)) {
+      setSelectedCapabilitiesMap(removeUncheckedCaps(checkedAppCaps));
+      setDisabledCapabilities(removeUncheckedCaps(checkedAppCaps));
+    }
+    // setDisabledCapabilities comes from outside, so we don't need to add it to the dependencies list
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkedAppCaps, isCapabilitiesLoading]);
 
   return {
     capabilities: memoizedCapabilities,
@@ -64,6 +112,6 @@ export const useApplicationCapabilities = (checkedAppIdsMap, options = {}) => {
     roleCapabilitiesListNames,
     setSelectedCapabilitiesMap,
     isLoading: isCapabilitiesLoading,
-    queryKeys
+    queryKeys,
   };
 };

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.test.js
@@ -27,7 +27,10 @@ describe('useApplicationCapabilities', () => {
 
   it('should test if returning fields and methods are defined', () => {
     useChunkedApplicationCapabilities.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap: { cap1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
 
     expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
     expect(result.current.roleCapabilitiesListIds).toStrictEqual([]);
@@ -43,7 +46,10 @@ describe('useApplicationCapabilities', () => {
     ];
     useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items, isLoading: false });
 
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap:{ cap1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
 
     expect(result.current.capabilities).toStrictEqual({
       data:  [
@@ -71,11 +77,42 @@ describe('useApplicationCapabilities', () => {
 
   it('should set empty capabilities in the case of empty appIds', async () => {
     useChunkedApplicationCapabilities.mockClear().mockReturnValue({ items: [], isLoading: false, queryKeys: [] });
-    const { result } = renderHook(useApplicationCapabilities, { initialProps: {} });
+    const { result } = renderHook(useApplicationCapabilities, { initialProps: { checkedAppIdsMap: {}, setDisabledCapabilities: jest.fn() } });
 
     await waitFor(async () => {
       expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
       expect(result.current.selectedCapabilitiesMap).toStrictEqual({});
     });
+  });
+
+  it('should remove unchecked capabilities from selectedCapabilitiesMap', async () => {
+    useChunkedApplicationCapabilities.mockClear().mockReturnValue({
+      items: [
+        { id: 1, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    const { result, rerender } = renderHook(useApplicationCapabilities, { initialProps: {
+      checkedAppIdsMap: { app1: true },
+      setDisabledCapabilities: jest.fn()
+    } });
+
+    await waitFor(() => {
+      result.current.setSelectedCapabilitiesMap({ 333: true, 222: true });
+    });
+
+    rerender({ checkedAppIdsMap:{ app2: true }, setDisabledCapabilities: jest.fn() });
+    expect(result.current.selectedCapabilitiesMap).toEqual({ 222:true, 333: true });
+
+    useChunkedApplicationCapabilities.mockClear().mockReturnValue({
+      items: [
+        { id: 222, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    rerender({ checkedAppIdsMap:{ app2:true }, setDisabledCapabilities: jest.fn() });
+    expect(result.current.selectedCapabilitiesMap).toEqual({ 222:true });
   });
 });

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -1,15 +1,14 @@
 import keyBy from 'lodash/keyBy';
 import { useEffect, useMemo, useState } from 'react';
 
+import isEmpty from 'lodash/isEmpty';
 import {
-  extractSelectedIdsFromObject,
   getCapabilitiesGroupedByTypeAndResource,
-  getOnlyIntersectedWithApplicationsCapabilities
 } from '../../utils';
 import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCapabilitySets';
 
 /**
- * Customhook that fetches and manages capability sets for a given list of checked application IDs.
+ * Custom hook that fetches and manages capability sets for a given list of checked application IDs.
  *
  * @param {Object} checkedAppIdsMap - An object mapping application IDs to boolean values indicating whether they are checked.
  *   Using this object, the hook will fetch the capability sets for the selected applications.
@@ -22,10 +21,10 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
  *   - isLoading: A boolean indicating whether capability sets are currently being fetched.
  */
 
-export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => {
+export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} }) => {
   const { tenantId } = options;
 
-  const selectedAppIds = extractSelectedIdsFromObject(checkedAppIdsMap);
+  const selectedAppIds = Object.keys(checkedAppIdsMap);
   const {
     items: capabilitySets,
     isLoading: isCapabilitySetsLoading,
@@ -33,7 +32,7 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
   } = useChunkedApplicationCapabilitySets(selectedAppIds, { tenantId });
 
   const [selectedCapabilitySetsMap, setSelectedCapabilitySetsMap] = useState({});
-  const roleCapabilitySetsListIds = extractSelectedIdsFromObject(selectedCapabilitySetsMap);
+  const roleCapabilitySetsListIds = Object.keys(selectedCapabilitySetsMap);
 
   const roleCapabilitySetsListNames = useMemo(() => {
     const capabilitySetsMap = keyBy(capabilitySets, 'id');
@@ -43,25 +42,57 @@ export const useApplicationCapabilitySets = (checkedAppIdsMap, options = {}) => 
       .filter(Boolean);
   }, [capabilitySets, roleCapabilitySetsListIds]);
 
-  useEffect(() => {
-    if (!isCapabilitySetsLoading) {
-      const updatedSelectedCapabilitySetsMap = getOnlyIntersectedWithApplicationsCapabilities(capabilitySets, roleCapabilitySetsListIds);
-      setSelectedCapabilitySetsMap(updatedSelectedCapabilitySetsMap);
-    }
-    // isCapabilitySetsLoading only information we need to know if capability sets fetched
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCapabilitySetsLoading]);
-
   const memoizedCapabilitySets = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilitySets), [capabilitySets]);
 
+  const checkedAppCapSets = useMemo(
+    () => capabilitySets.reduce((acc, capSet) => {
+      acc[capSet.id] = true;
+      return acc;
+    }, {}),
+    [capabilitySets],
+  );
+
+  /*
+    What happens in useEffect?
+    Our useApplicationCapabilitySets hook receives a list of the selected applications as argument,
+    and we retrieve the capability sets ONLY for the selected applications.
+    The user will then be able to select from the provided capabilitySets.
+    useEffect handles the situation where the user changes the selected applications, causing new capabilitySets to be retrieved.
+    However, previously selected capability sets may no longer be present in the new list of selected application capability sets.
+    It filters them by checking whether the selected capability set is included in the new list of capabilitySets.
+    It iterates over selectedCapabilitySets, and if any of them are not in the new list of capabilitySets, they are removed.
+    Example,
+      const selectedCapabilitiesMap = { id1: true, id2: true },
+            checkedAppCapSets = { id1: true };
+     Since checkedAppCapSets does not include id2, it is removed from selectedCapabilitySetsMap.
+   */
+
+  useEffect(() => {
+    if (!isCapabilitySetsLoading && !isEmpty(checkedAppCapSets)) {
+      setSelectedCapabilitySetsMap((prevCapSets) => {
+        const copy = { ...prevCapSets };
+        let hasChanged = false;
+
+        for (const capSet in copy) {
+          if (!(capSet in checkedAppCapSets)) {
+            delete copy[capSet];
+            hasChanged = true;
+          }
+        }
+
+        return hasChanged ? copy : prevCapSets;
+      });
+    }
+  }, [checkedAppCapSets, isCapabilitySetsLoading]);
+
   return {
-    capabilitySets:memoizedCapabilitySets,
+    capabilitySets: memoizedCapabilitySets,
     capabilitySetsList: capabilitySets,
     selectedCapabilitySetsMap,
     setSelectedCapabilitySetsMap,
     roleCapabilitySetsListIds,
     roleCapabilitySetsListNames,
     isLoading: isCapabilitySetsLoading,
-    queryKeys
+    queryKeys,
   };
 };

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.test.js
@@ -32,7 +32,9 @@ describe('useApplicationCapabilitySets', () => {
 
   it('should test if returning fields and methods are defined', () => {
     useChunkedApplicationCapabilitySets.mockReset().mockReturnValue({ items: [], isLoading: false, queryKeys: [['key1', 'key2']] });
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     expect(result.current.capabilitySets).toStrictEqual({ data: [], settings: [], procedural: [] });
     expect(result.current.roleCapabilitySetsListIds).toStrictEqual([]);
@@ -48,7 +50,9 @@ describe('useApplicationCapabilitySets', () => {
     ];
     useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({ items, isLoading: false });
 
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: { cap1: true } });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     expect(result.current.capabilitySets).toStrictEqual({
       data:  [
@@ -76,11 +80,43 @@ describe('useApplicationCapabilitySets', () => {
 
   it('should set empty capabilities in the case of empty appIds', async () => {
     useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({ items: [], isLoading: false });
-    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {} });
+    const { result } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { cap1: true }
+    } });
 
     await waitFor(async () => {
       expect(result.current.capabilitySets).toStrictEqual({ data: [], settings: [], procedural: [] });
       expect(result.current.selectedCapabilitySetsMap).toStrictEqual({});
     });
+  });
+
+  it('should remove unchecked capability sets from selectedCapabilitySetsMap', async () => {
+    useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({
+      items: [
+        { id: 1, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    const { result, rerender } = renderHook(useApplicationCapabilitySets, { initialProps: {
+      checkedAppIdsMap: { app1: true }
+    } });
+
+    await waitFor(() => {
+      result.current.setSelectedCapabilitySetsMap({ 333: true, 222: true });
+    });
+
+    rerender({ checkedAppIdsMap:{ app2: true } });
+    expect(result.current.selectedCapabilitySetsMap).toEqual({ 222:true, 333: true });
+
+    useChunkedApplicationCapabilitySets.mockClear().mockReturnValue({
+      items: [
+        { id: 222, applicationId: 'app1', type: 'data', action:'edit', resource: 'r1' },
+      ],
+      isLoading: false
+    });
+
+    rerender({ checkedAppIdsMap:{ app2:true } });
+    expect(result.current.selectedCapabilitySetsMap).toEqual({ 222:true });
   });
 });


### PR DESCRIPTION
Applications provide capabilities that may be assigned to roles. Unselecting an application when editing a role thus removes all the capabilities provided by that application. Previously, capabilities from unselected applications may still have been shown.

Changed hooks receives a list of the selected applications as argument, and we retrieve the capabilities ONLY for the selected applications. The user will then be able to select from the provided capabilities. useEffect handles the situation where the user changes the selected applications, causing new capabilities/sets to be retrieved.

However, previously selected capabilities may no longer be present in the new list of selected application capabilities/sets. It filters them by checking whether the selected capability/set is included in the new list of capabilities/sets.
It iterates over `selectedCapabilitiesMap`, `disabledCapabilities`, and if any of them are not in the new list of capabilities/sets, they are removed.

Example,
```
const selectedCapabilitiesMap = { id1: true, id2: true };
const disabledCapabilities = { id3: true };
const checkedAppCaps = { id1: true };
```
1. Since `checkedAppCaps` does not include `id2`, it is removed from `selectedCapabilitiesMap`.
2. Since `checkedAppCaps` does not include `id3`, it is removed from `disabledCapabilities`.

Refs UISAUTHCOM-43

cherry-picked from 3df00119bbd125f9e1a109a91b66445ff12c6775 
cherry-picked from 0f5769544f73808dc159813cfc48aade426631a8
