### PR TITLE
UISAUTHCOM-45: fix jest-axe reports a11y warnings

### DIFF
--- a/lib/Capabilities/CapabilitiesGrid/CapabilitiesGrid.js
+++ b/lib/Capabilities/CapabilitiesGrid/CapabilitiesGrid.js
@@ -59,6 +59,7 @@ export const CapabilitiesGrid = ({
       onChange={(event) => {
         toggleCapabilitiesHeaderCheckbox(event, type, action);
       }}
+      aria-label={formatMessage({ id:'stripes-authorization-components.columns.header.checkbox' }, { action })}
     /></div>;
   };
 

--- a/lib/Capabilities/constants.js
+++ b/lib/Capabilities/constants.js
@@ -21,32 +21,31 @@ export const CAPABILITIES_COLUMN_NAMES = {
   create: 'create',
   delete: 'delete',
   manage: 'manage',
-  empty: '',
 };
 
 export const columnWidths = {
   data: {
     [CAPABILITIES_COLUMN_NAMES.application]: '30%',
     [CAPABILITIES_COLUMN_NAMES.resource]: '24%',
-    [CAPABILITIES_COLUMN_NAMES.view]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.edit]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.create]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.delete]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.manage]: '8%',
+    [CAPABILITIES_COLUMN_NAMES.view]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.edit]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.create]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.delete]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.manage]: '9%',
   },
   settings: {
     [CAPABILITIES_COLUMN_NAMES.application]: '30%',
     [CAPABILITIES_COLUMN_NAMES.resource]: '24%',
-    [CAPABILITIES_COLUMN_NAMES.view]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.edit]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.create]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.delete]: '8%',
-    [CAPABILITIES_COLUMN_NAMES.manage]: '8%',
+    [CAPABILITIES_COLUMN_NAMES.view]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.edit]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.create]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.delete]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.manage]: '9%',
   },
   procedural: {
     [CAPABILITIES_COLUMN_NAMES.application]: '40%',
     [CAPABILITIES_COLUMN_NAMES.resource]: '48%',
-    [CAPABILITIES_COLUMN_NAMES.execute]: '9%',
+    [CAPABILITIES_COLUMN_NAMES.execute]: '10%',
   }
 };
 
@@ -59,7 +58,6 @@ export const visibleColumns = {
     CAPABILITIES_COLUMN_NAMES.create,
     CAPABILITIES_COLUMN_NAMES.delete,
     CAPABILITIES_COLUMN_NAMES.manage,
-    CAPABILITIES_COLUMN_NAMES.empty,
   ],
   settings: [
     CAPABILITIES_COLUMN_NAMES.application,
@@ -69,13 +67,11 @@ export const visibleColumns = {
     CAPABILITIES_COLUMN_NAMES.create,
     CAPABILITIES_COLUMN_NAMES.delete,
     CAPABILITIES_COLUMN_NAMES.manage,
-    CAPABILITIES_COLUMN_NAMES.empty,
   ],
   procedural: [
     CAPABILITIES_COLUMN_NAMES.application,
     CAPABILITIES_COLUMN_NAMES.resource,
     CAPABILITIES_COLUMN_NAMES.execute,
-    CAPABILITIES_COLUMN_NAMES.empty,
   ]
 };
 

--- a/translations/stripes-authorization-components/en.json
+++ b/translations/stripes-authorization-components/en.json
@@ -28,6 +28,7 @@
   "columns.settings": "Settings/Settings sets",
   "columns.procedure": "Procedure",
   "columns.execute": "Execute",
+  "columns.header.checkbox": "Select all {action} capabilities",
   "crud.createRole": "Create role",
   "crud.deleteRole": "Delete role",
   "crud.deleteRoleConfirmation": "{rolename} will be deleted",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
[UISAUTHCOM-45](https://folio-org.atlassian.net/browse/UISAUTHCOM-45) - jest-axe reports a11y warnings
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
