### PR TITLE
UISAUTHCOM-48: fix cap set remains assigned after selecting and then deselecting it when creating an authorization role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Change history for stripes-authorization-components
 
+## [1.0.3](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.3) (2025-02-07)
+[Full Changelog](https://github.com/folio-org/stripes-authorization-components/compare/v1.0.1...v1.0.3)
+
+* [UISAUTHCOM-48](https://folio-org.atlassian.net/browse/UISAUTHCOM-48) Fix capability set remains assigned after selecting and then deselecting it when creating an authorization role
+
 ## [1.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.2) (2025-02-07)
-[Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v1.0.1...v1.0.2)
+[Full Changelog](https://github.com/folio-org/stripes-authorization-components/compare/v1.0.1...v1.0.2)
 
 * [UISAUTHCOM-43](https://folio-org.atlassian.net/browse/UISAUTHCOM-43) Fix capabilities from unselected application sometimes shown as assigned for a role after editing.
 
 ## [1.0.1](https://github.com/folio-org/stripes-authorization-components/tree/v1.0.1) (2024-11-08)
-[Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v1.0.0...v1.0.1)
+[Full Changelog](https://github.com/folio-org/stripes-authorization-components/compare/v1.0.0...v1.0.1)
 
 * [UISAUTHCOM-36](https://folio-org.atlassian.net/browse/UISAUTHCOM-36) Avoid extra capability requests for role sharing when not in central tenant
 * [UISAUTHCOM-37](https://folio-org.atlassian.net/browse/UISAUTHCOM-37) ECS - Add Tenant identifier to title of Select user modal.

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 import {
+  extractSelectedIdsFromObject,
   getCapabilitiesGroupedByTypeAndResource,
 } from '../../utils';
 import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCapabilitySets';
@@ -32,7 +33,7 @@ export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} })
   } = useChunkedApplicationCapabilitySets(selectedAppIds, { tenantId });
 
   const [selectedCapabilitySetsMap, setSelectedCapabilitySetsMap] = useState({});
-  const roleCapabilitySetsListIds = Object.keys(selectedCapabilitySetsMap);
+  const roleCapabilitySetsListIds = extractSelectedIdsFromObject(selectedCapabilitySetsMap);
 
   const roleCapabilitySetsListNames = useMemo(() => {
     const capabilitySetsMap = keyBy(capabilitySets, 'id');


### PR DESCRIPTION
Refs [UISAUTHCOM-48](https://folio-org.atlassian.net/browse/UISAUTHCOM-48).

**Approach**: updated line code of useApplicationCapabilitySets accidentally got into the release. Revert the line back 
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
