### PR TITLE
UISAUTHCOM-55 Filter out any capabilities with property `dummyCapability = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * *BREAKING* [UISAUTHCOM-46](https://folio-org.atlassian.net/browse/UISAUTHCOM-46) migrate react-intl to v7.
 * *BREAKING* [UISAUTHCOM-50](https://folio-org.atlassian.net/browse/UISAUTHCOM-50) migrate stripes dependencies to their Sunflower versions. 
+* [UISAUTHCOM-55](https://folio-org.atlassian.net/browse/UISAUTHCOM-55) Filter out any capabilities with property `dummyCapability = true` since they are invalid. API will suppress once MODROLESKC-285 is completed, but this immediately fixes the issue in the UI.
 
 ## 1.1.0 
 

--- a/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.js
+++ b/lib/hooks/useChunkedApplicationCapabilities/useChunkedApplicationCapabilities.js
@@ -18,7 +18,8 @@ export const useChunkedApplicationCapabilities = (appIds, options = {}) => {
     ids: appIds,
     limit: CAPABILITIES_LIMIT,
     idName: 'applicationId',
-    reduceFunction: data => data.flatMap(d => d.data?.capabilities || []),
+    // Remove dummy capabilities from the results, if any, since they are not valid.
+    reduceFunction: data => data.flatMap(d => d.data?.capabilities.filter((c) => c && !c.dummyCapability) || []),
     queryOptions:{
       enabled: !isEmpty(appIds)
     },


### PR DESCRIPTION
- Fixes [UISAUTHCOM-55](https://folio-org.atlassian.net/browse/UISAUTHCOM-55).
- Filter out any capabilities with property `dummyCapability = true` since they are invalid. API will suppress once [MODROLESKC-285](https://folio-org.atlassian.net/browse/MODROLESKC-285) is completed, but this immediately fixes the issue in the UI.