### PR TITLE
UISAUTHCOM-51: Old capabilities are not removed when editing a shared role (which had a set before sharing) in "Consortium manager"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-authorization-components
 
-# [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.1)
+# [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 
 * [UISAUTHCOM-51](https://folio-org.atlassian.net/browse/UISAUTHCOM-51) Provide `expand=false` parameter to `useRoleCapabilities` that used in `useInitalRoleSharing` to correctly retrieve directly assigned capabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authorization-components
 
+# [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.1)
+
+* [UISAUTHCOM-51](https://folio-org.atlassian.net/browse/UISAUTHCOM-51) Provide `expand=false` parameter to `useRoleCapabilities` that used in `useInitalRoleSharing` to correctly retrieve directly assigned capabilities
+
 # [2.0.1](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.1) (2025-04-09)
 
 * [UISAUTHCOM-55](https://folio-org.atlassian.net/browse/UISAUTHCOM-55) Filter out any capabilities with property `dummyCapability = true` since they are invalid. API will suppress once MODROLESKC-285 is completed, but this immediately fixes the issue in the UI.

--- a/lib/hooks/consortia/useInitialRoleSharing/useInitialRoleSharing.js
+++ b/lib/hooks/consortia/useInitialRoleSharing/useInitialRoleSharing.js
@@ -18,7 +18,7 @@ export const useInitialRoleSharing = (role, { tenantId }) => {
   );
 
   const { initialRoleCapabilitySetsNames } = useRoleCapabilitySets(role?.id, centralTenantId, { enabled: sharingEnabled });
-  const { initialRoleCapabilitiesNames } = useRoleCapabilities(role?.id, centralTenantId, true, { enabled: sharingEnabled });
+  const { initialRoleCapabilitiesNames } = useRoleCapabilities(role?.id, centralTenantId, false, { enabled: sharingEnabled });
 
   const { upsertSharedRole, isLoading } = useRoleSharing();
 

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -24,6 +24,7 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  * @param {string} roleId The Role ID.
  * @param {string} tenant The Tenant ID. Passes into `useOkapiKy` which will default to `stripes.okapi.tenant` if omitted.
  * @param {boolean} expand Defines if capability sets must be expanded in the API response. Defaults to `false`.
+ * with expand=false API returns capabilities that was assigned directly, not by capability set.
  * @param {object} options Any additional options to pass into `useQuery()`.
  * @returns Capabilities.
  */


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose

Refs [UISAUTHCOM-51](https://folio-org.atlassian.net/browse/UISAUTHCOM-51). 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

Using `expand=true` also returns capabilities included via capability sets. To retrieve only directly assigned capabilities, provide `expand=false` as a parameter, e.g., `roles/{id}?expand=false`.

Example:
Suppose a role has a capability set `capSet` that includes the `ui-capability`. If you fetch the role's capabilities with `expand=true`, you'll receive `ui-capability` because it's part of `capSet`.
To get only the capabilities that are directly assigned to the role (excluding those inherited from capability sets), use `expand=false`.



<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
