### PR TITLE
UISAUTHCOM-59 Increase default timeout for create role API calls to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # [2.1.0] In Progress
 
 * [UISAUTHCOM-60](https://folio-org.atlassian.net/browse/UISAUTHCOM-60) Add new `hideUserLink` prop to `RoleDetails` component that will display users in assigned users list as a text if enabled.
-* [UISAUTHCOM-59](https://folio-org.atlassian.net/browse/UISAUTHCOM-59) Increase request timeout in `useCreateRoleMutation`, `useEditRoleMutation`.
+* [UISAUTHCOM-59](https://folio-org.atlassian.net/browse/UISAUTHCOM-59) Increase request timeout in `useCreateRoleMutation`, `useEditRoleMutation` from default 30 seconds to 10 minutes. This can be decreased if back-end performance improves.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/hooks/useCreateRoleMutation/useCreateRoleMutation.js
+++ b/lib/hooks/useCreateRoleMutation/useCreateRoleMutation.js
@@ -8,10 +8,13 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 
+// Currently set to 10 minutes, but this can be reduced if back-end response times are improved.
+const REQUEST_TIMEOUT = 600000;
+
 export const useCreateRoleMutation = (roleCapabilitiesListIds, capabilitySetListIds, handleError, options = {}) => {
   const { tenantId } = options;
 
-  const ky = useOkapiKy({ tenant: tenantId, timeout: 180000 });
+  const ky = useOkapiKy({ tenant: tenantId });
   const queryClient = useQueryClient();
   const [namespace] = useNamespace();
   const { mutateAsync, isLoading } = useMutation({
@@ -19,10 +22,10 @@ export const useCreateRoleMutation = (roleCapabilitiesListIds, capabilitySetList
     onSuccess: async (newRole) => {
       await queryClient.invalidateQueries(namespace);
       if (roleCapabilitiesListIds.length > 0) {
-        await ky.post('roles/capabilities', { json: { roleId: newRole.id, capabilityIds: roleCapabilitiesListIds } }).json();
+        await ky.post('roles/capabilities', { json: { roleId: newRole.id, capabilityIds: roleCapabilitiesListIds }, timeout: REQUEST_TIMEOUT }).json();
       }
       if (capabilitySetListIds.length > 0) {
-        await ky.post('roles/capability-sets', { json: { roleId: newRole.id, capabilitySetIds: capabilitySetListIds } }).json();
+        await ky.post('roles/capability-sets', { json: { roleId: newRole.id, capabilitySetIds: capabilitySetListIds }, timeout: REQUEST_TIMEOUT }).json();
       }
     },
     onError: handleError,


### PR DESCRIPTION
- Fixes [UISAUTHCOM-59](https://folio-org.atlassian.net/browse/UISAUTHCOM-59), which previously saw an error toast message when creating a new role because the `POST /roles/capabilities` and/or `POST /roles/capability-sets` calls would time out past the browser default of 30 seconds.
- Note that while there was a property of `timeout: 180000` previously passed in, it was not in the correct location and therefore was ignored by the API calls and instead used the browser deault.