### PR TITLE
[UISAUTHCOM-66] Suppress edit and delete menu buttons for default roles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UISAUTHCOM-60](https://folio-org.atlassian.net/browse/UISAUTHCOM-60) Add new `hideUserLink` prop to `RoleDetails` component that will display users in assigned users list as a text if enabled.
 * [UISAUTHCOM-59](https://folio-org.atlassian.net/browse/UISAUTHCOM-59) Increase request timeout in `useCreateRoleMutation`, `useEditRoleMutation` from default 30 seconds to 10 minutes. This can be decreased if back-end performance improves.
 * [UISAUTHCOM-65](https://folio-org.atlassian.net/browse/UISAUTHCOM-65) Provide the ability to pass props to control whether certain actions can be performed.
+* [UISAUTHCOM-66](https://folio-org.atlassian.net/browse/UISAUTHCOM-66) Suppress edit and delete menu buttons for default roles.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/RoleDetails/RoleDetails.js
+++ b/lib/RoleDetails/RoleDetails.js
@@ -29,7 +29,7 @@ import {
   useStripes,
 } from '@folio/stripes/core';
 
-import { MUTATION_ACTION_TYPE } from '../constants';
+import { MUTATION_ACTION_TYPE, ROLE_TYPE } from '../constants';
 import {
   useDeleteRoleMutation,
   useInitialRoleSharing,
@@ -93,6 +93,7 @@ export const RoleDetails = ({
     isLoading: isSharedRoleDeleting,
   } = useRoleSharing();
 
+  const isDefaultRecord = role?.type === ROLE_TYPE.default;
   const isRoleShared = Boolean(stripes.hasInterface('consortia') && isShared(role));
   const targetTenantId = tenantId || stripes.okapi.tenant;
   const isTargetTenantCentral = isTenantConsortiumCentral(stripes, targetTenantId);
@@ -111,13 +112,13 @@ export const RoleDetails = ({
       || isRoleShared
     );
 
-    const isEditAllowed = canEdit && (
+    const isEditAllowed = canEdit && !isDefaultRecord && (
       isRoleShared
         ? stripes.hasPerm('consortia.sharing-roles-all.item.post')
         : stripes.hasPerm('roles.item.put')
     );
     const isCreateAllowed = canCreate && stripes.hasPerm('roles.item.post');
-    const isDeleteAllowed = canDelete && (
+    const isDeleteAllowed = canDelete && !isDefaultRecord && (
       isRoleShared
         ? stripes.hasPerm('consortia.sharing-roles-all.item.delete')
         : stripes.hasPerm('roles.item.delete')

--- a/lib/RoleDetails/RoleDetails.test.js
+++ b/lib/RoleDetails/RoleDetails.test.js
@@ -290,5 +290,18 @@ describe('RoleDetails component', () => {
 
       expect(screen.getByText('stripes-authorization-components.crud.duplicate')).toBeInTheDocument();
     });
+
+    it('should hide edit and delete buttons, but show duplicate button if role is default', () => {
+      useRoleById.mockReturnValueOnce({
+        roleDetails: { ...defaultProps, ...getRoleData({ type: ROLE_TYPE.default }) },
+        isRoleDetailsLoaded: true,
+      });
+
+      renderComponent({ canEdit: true });
+
+      expect(screen.queryByText('stripes-authorization-components.crud.edit')).not.toBeInTheDocument();
+      expect(screen.queryByText('stripes-authorization-components.crud.delete')).not.toBeInTheDocument();
+      expect(screen.queryByText('stripes-authorization-components.crud.duplicate')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
- Fulfills [UISAUTHCOM-66](https://folio-org.atlassian.net/browse/UISAUTHCOM-66).
- When role type is default (from API response), `edit` and `delete` buttons will be suppressed. Previously, if a user tried to edit/delete a default role, the API would return an error since it is not allowed by design. 