### PR TITLE
[UISAUTHCOM-67] Match GET role capabilities query key to match edit request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UISAUTHCOM-59](https://folio-org.atlassian.net/browse/UISAUTHCOM-59) Increase request timeout in `useCreateRoleMutation`, `useEditRoleMutation` from default 30 seconds to 10 minutes. This can be decreased if back-end performance improves.
 * [UISAUTHCOM-65](https://folio-org.atlassian.net/browse/UISAUTHCOM-65) Provide the ability to pass props to control whether certain actions can be performed.
 * [UISAUTHCOM-66](https://folio-org.atlassian.net/browse/UISAUTHCOM-66) Suppress edit and delete menu buttons for default roles.
+* [UISAUTHCOM-67](https://folio-org.atlassian.net/browse/UISAUTHCOM-67) Match GET role capabilities query key to match edit request, so `react-query` `invalidateQueries()` is called and new data is fetched.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -188,8 +188,8 @@ export const RoleEdit = ({ path, tenantId }) => {
     }
   };
 
+  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
   const isLoading = isRoleMutating || isRoleSharing;
-  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded && !isLoading;
 
   useEffect(() => {
     if (isInitialDataReady) {

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -40,7 +40,7 @@ export const RoleEdit = ({ path, tenantId }) => {
     initialRoleCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
     capabilitiesAppIds
-  } = useRoleCapabilities(roleId, tenantId);
+  } = useRoleCapabilities(roleId, tenantId, true);
 
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
@@ -50,7 +50,7 @@ export const RoleEdit = ({ path, tenantId }) => {
     capabilitySetsCapabilities,
     isSuccess: isInitialRoleCapabilitySetsLoaded,
     capabilitySetsAppIds,
-  } = useRoleCapabilitySets(roleId, tenantId);
+  } = useRoleCapabilitySets(roleId, tenantId, true);
 
   const {
     capabilities,
@@ -188,8 +188,8 @@ export const RoleEdit = ({ path, tenantId }) => {
     }
   };
 
-  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
   const isLoading = isRoleMutating || isRoleSharing;
+  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded && !isLoading;
 
   useEffect(() => {
     if (isInitialDataReady) {


### PR DESCRIPTION
- Fixes [UISAUTHCOM-67](https://folio-org.atlassian.net/browse/UISAUTHCOM-67).
- Previously, after adding/removing certain capabilities from a role the change would be visible on the role detail screen, but when moving back to the edit screen the most recent change would not be visible until refreshing the browser.
- By matching the edit request query key, this allows `react-query` `invalidateQueries()` to be called and new data is fetched. This also matches the signature used elsewhere in the application (which updates properly).