### PR TITLE
[UISAUTHCOM-74] Ensure that deselecting a column of capability sets also deslects all child capabilities.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # production
 /build
+/translations/**/compiled/*
 
 # misc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * [UISAUTHCOM-67](https://folio-org.atlassian.net/browse/UISAUTHCOM-67) Match GET role capabilities query key to match edit request, so `react-query` `invalidateQueries()` is called and new data is fetched.
 * [UISAUTHCOM-68](https://folio-org.atlassian.net/browse/UISAUTHCOM-68) Group keycloak create errors together and ensure all user records in batch are attempted.
 * [UISAUTHCOM-70](https://folio-org.atlassian.net/browse/UISAUTHCOM-70) Fix slowness when typing in name/description fields, by having component re-render onBlur instead of every keystroke.
-* [UISAUTHCOM-69](https://folio-org.atlassian.net/browse/UISAUTHCOM-69) Display warning and require confirmation before unchecking an application for both Create and Edit Role.
 * [UISAUTHCOM-69](https://folio-org.atlassian.net/browse/UISAUTHCOM-69) Display warning and require confirmation before unchecking an application for both Create and Edit Role. Rename confirmation button from "Okay" to "Continue".
 * [UISAUTHCOM-72](https://folio-org.atlassian.net/browse/UISAUTHCOM-72) Pass `tenantId` prop to `<ViewMetaData>` component on the role details pane.
 * [UISAUTHCOM-73](https://folio-org.atlassian.net/browse/UISAUTHCOM-73) Include capabilities inside capability sets when calculating counts for warning when de-selecting an application assigned to a role.
@@ -17,7 +16,7 @@
 * [UISAUTHCOM-76](https://folio-org.atlassian.net/browse/UISAUTHCOM-76) Update the message for sharing a role to indicate that it can be a lengthy process.
 * [UISAUTHCOM-78](https://folio-org.atlassian.net/browse/UISAUTHCOM-78) Refactor timeout handling by introducing TIMEOUT constant for useOkapiKy in role sharing and delete role mutation hooks.
 * [UISAUTHCOM-81](https://folio-org.atlassian.net/browse/UISAUTHCOM-81) Increase default timeout for role mutations.
-* [UISAUTHCOM-74](https://folio-org.atlassian.net/browse/UISAUTHCOM-74) When previously saved capability sets are deselected, child capabilities are now deselected too.
+* [UISAUTHCOM-74](https://folio-org.atlassian.net/browse/UISAUTHCOM-74) When previously saved capability sets are deselected, child capabilities are now deselected too. Also, ensure that deselecting a column of capability sets also deslects all child capabilities.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -85,15 +85,15 @@ export function getCheckboxHandlers({
 
     const capSetCapabilities = selectedCapabilitySet.capabilities;
 
+    const newDisabledCapabilities = { ...disabledCapabilities };
+
     if (checked) {
-      const newDisabledCapabilities = { ...disabledCapabilities };
       newSelectedCapabilitySetsMap[capabilitySetId] = true;
       capSetCapabilities.forEach((cap) => {
         newDisabledCapabilities[cap] = true;
       });
       setDisabledCapabilities(newDisabledCapabilities);
     } else {
-      const newDisabledCapabilities = { ...disabledCapabilities };
       delete newSelectedCapabilitySetsMap[capabilitySetId];
       capSetCapabilities.forEach((cap) => {
         delete newDisabledCapabilities[cap];
@@ -147,16 +147,16 @@ export function getCheckboxHandlers({
    */
   const toggleCapabilitySetsHeaderCheckbox = (event, type, action) => {
     const { checked } = event.target;
+    const newDisabledCapabilities = { ...disabledCapabilities };
+    const typeActionCapSets = actionCapabilitySets[type][action]?.reduce(
+      (acc, value) => {
+        acc[value] = true;
+        return acc;
+      },
+      {},
+    ) || {};
 
     if (checked) {
-      const newDisabledCapabilities = { ...disabledCapabilities };
-      const typeActionCapSets = actionCapabilitySets[type][action]?.reduce(
-        (acc, value) => {
-          acc[value] = true;
-          return acc;
-        },
-        {},
-      ) || {};
       const updatedCapabilitySetsMap = {
         ...selectedCapabilitySetsMap,
         ...typeActionCapSets,
@@ -170,27 +170,26 @@ export function getCheckboxHandlers({
         });
       });
       setSelectedCapabilitySetsMap(updatedCapabilitySetsMap);
-      setDisabledCapabilities(newDisabledCapabilities);
     } else {
-      const newDisabledCapabilities = {};
-      const filteredFromSelectedCapabilitySets = Object.fromEntries(
-        Object.entries(selectedCapabilitySetsMap)
-          .filter(([capSet]) => !actionCapabilitySets[type][action]?.includes(capSet)),
-      );
+      const newSelectedCapabilities = { ...selectedCapabilitiesMap };
+      const newSelectedCapabilitySetsMap = { ...selectedCapabilitySetsMap };
 
-      Object.keys(filteredFromSelectedCapabilitySets)
-        .forEach(capSet => {
-          const found = capabilitySetsList.find(c => c.id === capSet);
-          if (!found) return;
+      Object.keys(typeActionCapSets).forEach((capSet) => {
+        const found = capabilitySetsList.find(c => c.id === capSet);
+        if (!found) return;
 
-          found.capabilities.forEach(c => {
-            newDisabledCapabilities[c] = true;
-          });
+        delete newSelectedCapabilitySetsMap[capSet];
+
+        found.capabilities.forEach((c) => {
+          delete newDisabledCapabilities[c];
+          delete newSelectedCapabilities[c];
         });
+      });
 
-      setSelectedCapabilitySetsMap(filteredFromSelectedCapabilitySets);
-      setDisabledCapabilities(newDisabledCapabilities);
+      setSelectedCapabilitySetsMap(newSelectedCapabilitySetsMap);
+      setSelectedCapabilitiesMap(newSelectedCapabilities);
     }
+    setDisabledCapabilities(newDisabledCapabilities);
   };
 
   /**

--- a/lib/Role/utils.test.js
+++ b/lib/Role/utils.test.js
@@ -567,5 +567,60 @@ describe('useCheckboxHandlers', () => {
       expect(result.unselectedAppIds).toContain('3');
       expect(result.unselectedCapabilityCount).toBe(2);
     });
+
+    it('toggleCapabilitySetsHeaderCheckbox should handle mixed checked and unchecked states', () => {
+      const { toggleCapabilitySetsHeaderCheckbox } = getCheckboxHandlers({
+        selectedCapabilitiesMap: { 'cap1': true },
+        setSelectedCapabilitiesMap,
+        capabilitySetsList: [
+          {
+            id: 'setA',
+            name: 'Set A',
+            capabilities: ['cap1', 'cap2'],
+          },
+          {
+            id: 'setB',
+            name: 'Set B',
+            capabilities: ['cap3'],
+          },
+        ],
+        setDisabledCapabilities,
+        selectedCapabilitySetsMap: { 'setA': true },
+        setSelectedCapabilitySetsMap,
+        actionCapabilities,
+        disabledCapabilities: { 'cap1': true, 'cap2': true },
+        actionCapabilitySets: {
+          data: {
+            view: ['setA', 'setB'],
+          },
+          settings: {},
+          procedural: {},
+        },
+      });
+
+      toggleCapabilitySetsHeaderCheckbox(
+        { target: { checked: true } },
+        'data',
+        'view'
+      );
+
+      expect(setSelectedCapabilitySetsMap).toHaveBeenCalledWith({ 'setA': true, 'setB': true });
+      expect(setSelectedCapabilitiesMap).not.toHaveBeenCalled();
+      expect(setDisabledCapabilities).toHaveBeenCalledWith({ 'cap1': true, 'cap2': true, 'cap3': true });
+
+      setSelectedCapabilitiesMap.mockClear();
+      setSelectedCapabilitySetsMap.mockClear();
+      setDisabledCapabilities.mockClear();
+
+      toggleCapabilitySetsHeaderCheckbox(
+        { target: { checked: false } },
+        'data',
+        'view'
+      );
+
+      expect(setSelectedCapabilitiesMap).toHaveBeenCalledWith({});
+      expect(setSelectedCapabilitiesMap).toHaveBeenCalledWith({});
+      expect(setDisabledCapabilities).toHaveBeenCalledWith({});
+    });
   });
 });


### PR DESCRIPTION
- Fixes issue noted by QA in https://folio-org.atlassian.net/browse/UISAUTHCOM-74?focusedCommentId=287518.
- Added support in `toggleCapabilitySetsHeaderCheckbox` to properly deselect child capabilities when deslecting an entire action column of capability sets.
- Simplified logic in `toggleCapabilitySetsHeaderCheckbox`, so that instead of reducing list to remaining checked capability sets, instead it determines unchecked capability sets and then unchecks child capabilities, which is the exact flow the user expects to see.