### PR TITLE
UISAUTHCOM-90 Add validation to ensure role names are unique across tenants when editing shared authorization roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [UISAUTHCOM-88](https://folio-org.atlassian.net/browse/UISAUTHCOM-88) Escape CQL values on sharing validation request.
 * [UISAUTHCOM-87](https://folio-org.atlassian.net/browse/UISAUTHCOM-87) OmittheerrantwhitespacethattripsupPluggable's`children`'slengthcalculation.
 * [UISAUTHCOM-83](https://folio-org.atlassian.net/browse/UISAUTHCOM-83) Preserve session-selected capabilities when unchecking a capability set that includes them. Keep `isInitialDataReady` false while fetching data to prevent data from being displayed after the page is reopened.
+* [UISAUTHCOM-90](https://folio-org.atlassian.net/browse/UISAUTHCOM-90) Add validation to ensure role names are unique across tenants when editing shared authorization roles.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/hooks/consortia/index.js
+++ b/lib/hooks/consortia/index.js
@@ -2,3 +2,4 @@ export { useInitialRoleSharing } from './useInitialRoleSharing';
 export { usePolicySharing } from './usePolicySharing';
 export { usePublishCoordinator } from './usePublishCoordinator';
 export { useRoleSharing } from './useRoleSharing';
+export { useSharedRoleValidator } from './useSharedRoleValidator';

--- a/lib/hooks/consortia/useInitialRoleSharing/useInitialRoleSharing.js
+++ b/lib/hooks/consortia/useInitialRoleSharing/useInitialRoleSharing.js
@@ -1,27 +1,16 @@
 import { useCallback } from 'react';
-import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
 
-import {
-  useOkapiKy,
-  useStripes,
-} from '@folio/stripes/core';
-import { escapeCqlValue } from '@folio/stripes/util';
+import { useStripes } from '@folio/stripes/core';
 
-import {
-  getConsortium,
-  getConsortiumCentralTenantId,
-  getConsortiumTenants,
-  RoleMutationClientError,
-} from '../../../utils';
+import { getConsortiumCentralTenantId } from '../../../utils';
 import { useRoleCapabilities } from '../../useRoleCapabilities';
 import { useRoleCapabilitySets } from '../../useRoleCapabilitySets';
-import { usePublishCoordinator } from '../usePublishCoordinator';
 import { useRoleSharing } from '../useRoleSharing';
+import { useSharedRoleValidator } from '../useSharedRoleValidator';
 
 export const useInitialRoleSharing = (role, { tenantId }) => {
   const stripes = useStripes();
-  const intl = useIntl();
 
   const centralTenantId = getConsortiumCentralTenantId(stripes);
   const activeTenantId = stripes.okapi.tenant;
@@ -31,71 +20,14 @@ export const useInitialRoleSharing = (role, { tenantId }) => {
     && stripes.hasPerm('consortia.sharing-roles-all.item.post')
   );
 
-  const ky = useOkapiKy({ tenant: centralTenantId });
-  const { initPublicationRequest } = usePublishCoordinator();
-
   const { initialRoleCapabilitySetsNames } = useRoleCapabilitySets(role?.id, centralTenantId, { enabled: sharingEnabled });
   const { initialRoleCapabilitiesNames } = useRoleCapabilities(role?.id, centralTenantId, false, { enabled: sharingEnabled });
 
   const { upsertSharedRole, isLoading } = useRoleSharing();
-
-  const validateRoleBeforeSharing = useCallback(async () => {
-    // Check if the role with the same name already exists in other tenants
-    // If it does, we should not share the role and show an error message to the user
-    const { tenants } = await getConsortiumTenants(ky, getConsortium(stripes)?.id);
-    const tenantsMap = new Map(tenants.map((tenant) => [tenant.id, tenant]));
-
-    const {
-      publicationErrors,
-      publicationResults,
-    } = await initPublicationRequest({
-      url: `/roles?query=name=="${escapeCqlValue(role.name)}"`,
-      method: 'GET',
-      tenants: Array.from(tenantsMap.keys()).filter(id => id !== centralTenantId),
-    });
-
-    // If there are any errors related to publication, we should not share the role and show an error message to the user
-    if (publicationErrors.length) {
-      const message = intl.formatMessage(
-        { id: 'stripes-authorization-components.role.share.error.validation' },
-        {
-          tenants: (
-            publicationErrors
-              .map(({ tenantId: id }) => tenantsMap.get(id).name)
-              .sort((a, b) => a.localeCompare(b))
-              .join(', ')
-          )
-        }
-      );
-
-      throw new Error(message);
-    }
-
-    const conflictingTenants = publicationResults
-      .filter(({ response }) => response.totalRecords > 0)
-      .map(({ tenantId: id }) => tenantsMap.get(id).name)
-      .sort((a, b) => a.localeCompare(b));
-
-    // If there are any tenants with conflicting role names, we should not share the role and show an error message to the user
-    if (conflictingTenants.length) {
-      const message = intl.formatMessage(
-        { id: 'stripes-authorization-components.role.share.error.duplicate' },
-        { tenants: conflictingTenants.join(', ') }
-      );
-
-      throw new RoleMutationClientError(message);
-    }
-  }, [
-    centralTenantId,
-    initPublicationRequest,
-    intl,
-    ky,
-    role?.name,
-    stripes,
-  ]);
+  const { validate: validateRoleBeforeSharing } = useSharedRoleValidator();
 
   const mutationFn = useCallback(async () => {
-    await validateRoleBeforeSharing();
+    await validateRoleBeforeSharing({ role });
 
     return upsertSharedRole({
       role,

--- a/lib/hooks/consortia/useRoleSharing/useRoleSharing.js
+++ b/lib/hooks/consortia/useRoleSharing/useRoleSharing.js
@@ -20,6 +20,7 @@ import {
 } from '../../../utils';
 import { PC_SHARING_DETAILS_KEYS } from '../../constants';
 import { usePublishCoordinator } from '../usePublishCoordinator';
+import { useSharedRoleValidator } from '../useSharedRoleValidator';
 
 const getPCRequestIds = (pcResponse) => {
   return pcResponse[PC_SHARING_DETAILS_KEYS.updateRolesPCIds] || pcResponse[PC_SHARING_DETAILS_KEYS.createRolesPCIds];
@@ -42,6 +43,7 @@ export const useRoleSharing = (options = {}) => {
   });
 
   const { getPublicationDetails } = usePublishCoordinator();
+  const { validate: validateSharedRole } = useSharedRoleValidator();
 
   const baseApi = `${CONSORTIA_API}/${consortiumId}/sharing/roles`;
 
@@ -108,6 +110,8 @@ export const useRoleSharing = (options = {}) => {
         shouldUpdateCapabilitySets,
         signal,
       } = data;
+
+      await validateSharedRole({ role });
 
       const { id: roleId, name: roleName } = role;
       const payload = {

--- a/lib/hooks/consortia/useRoleSharing/useRoleSharing.test.js
+++ b/lib/hooks/consortia/useRoleSharing/useRoleSharing.test.js
@@ -16,6 +16,16 @@ import {
 } from 'fixtures';
 import { useRoleSharing } from './useRoleSharing';
 
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  getConsortiumTenants: jest.fn(() => ({
+    tenants: [
+      { id: 'tenant-1', name: 'Tenant 1' },
+      { id: 'tenant-2', name: 'Tenant 2' },
+    ],
+  })),
+}));
+
 const queryClient = new QueryClient();
 
 const wrapper = ({ children }) => (

--- a/lib/hooks/consortia/useSharedRoleValidator/index.js
+++ b/lib/hooks/consortia/useSharedRoleValidator/index.js
@@ -1,0 +1,1 @@
+export { useSharedRoleValidator } from './useSharedRoleValidator';

--- a/lib/hooks/consortia/useSharedRoleValidator/useSharedRoleValidator.js
+++ b/lib/hooks/consortia/useSharedRoleValidator/useSharedRoleValidator.js
@@ -1,0 +1,88 @@
+import { useIntl } from 'react-intl';
+import { useMutation } from 'react-query';
+
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+import { escapeCqlWildcards } from '@folio/stripes/util';
+
+import { ROLE_TYPE } from '../../../constants';
+import {
+  getConsortium,
+  getConsortiumCentralTenantId,
+  getConsortiumTenants,
+  RoleMutationClientError,
+} from '../../../utils';
+import { usePublishCoordinator } from '../usePublishCoordinator';
+
+export const useSharedRoleValidator = () => {
+  const stripes = useStripes();
+  const intl = useIntl();
+  const centralTenantId = getConsortiumCentralTenantId(stripes);
+  const ky = useOkapiKy({ tenant: centralTenantId });
+
+  const { initPublicationRequest } = usePublishCoordinator();
+
+  const { mutateAsync } = useMutation({
+    mutationFn: async ({ role }) => {
+      // Check if the role with the same name already exists in other tenants
+      // If it does, we should not share the role and show an error message to the user
+      const { tenants } = await getConsortiumTenants(ky, getConsortium(stripes)?.id);
+      const tenantsMap = new Map(tenants.map((tenant) => [tenant.id, tenant]));
+
+      const filtersMap = new Map([
+        ['name', [escapeCqlWildcards(role.name), '==']],
+        ['type', [ROLE_TYPE.consortium, '<>']],
+      ]);
+      const query = Array.from(filtersMap.entries())
+        .map(([filter, [value, operator]]) => `${filter}${operator}"${value}"`)
+        .join(' AND ');
+
+      const {
+        publicationErrors,
+        publicationResults,
+      } = await initPublicationRequest({
+        url: `/roles?query=${query}`,
+        method: 'GET',
+        tenants: Array.from(tenantsMap.keys()).filter(id => id !== centralTenantId),
+      });
+
+      // If there are any errors related to publication, we should not share the role and show an error message to the user
+      if (publicationErrors.length) {
+        const message = intl.formatMessage(
+          { id: 'stripes-authorization-components.role.share.error.validation' },
+          {
+            tenants: (
+              publicationErrors
+                .map(({ tenantId: id }) => tenantsMap.get(id).name)
+                .sort((a, b) => a.localeCompare(b))
+                .join(', ')
+            )
+          }
+        );
+
+        throw new RoleMutationClientError(message);
+      }
+
+      const conflictingTenants = publicationResults
+        .filter(({ response }) => response.totalRecords > 0)
+        .map(({ tenantId: id }) => tenantsMap.get(id).name)
+        .sort((a, b) => a.localeCompare(b));
+
+      // If there are any tenants with conflicting role names, we should not share the role and show an error message to the user
+      if (conflictingTenants.length) {
+        const message = intl.formatMessage(
+          { id: 'stripes-authorization-components.role.share.error.duplicate' },
+          { tenants: conflictingTenants.join(', ') }
+        );
+
+        throw new RoleMutationClientError(message);
+      }
+    },
+  });
+
+  return {
+    validate: mutateAsync,
+  };
+};

--- a/lib/hooks/consortia/useSharedRoleValidator/useSharedRoleValidator.test.js
+++ b/lib/hooks/consortia/useSharedRoleValidator/useSharedRoleValidator.test.js
@@ -1,0 +1,94 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  act,
+  renderHook,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import { usePublishCoordinator } from '../usePublishCoordinator';
+import { useSharedRoleValidator } from './useSharedRoleValidator';
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  getConsortiumTenants: jest.fn(() => ({
+    tenants: [
+      { id: 'tenant-1', name: 'Tenant 1' },
+      { id: 'tenant-2', name: 'Tenant 2' },
+    ],
+  })),
+}));
+jest.mock('../usePublishCoordinator', () => ({ usePublishCoordinator: jest.fn() }));
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const role = {
+  id: 'role-id',
+  name: 'role-name',
+};
+
+describe('useSharedRoleValidator', () => {
+  const initPublicationRequest = jest.fn(() => ({
+    publicationErrors: [],
+    publicationResults: [],
+  }));
+
+  beforeEach(() => {
+    usePublishCoordinator.mockReturnValue({ initPublicationRequest });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if there are some publication errors in some tenants', async () => {
+    initPublicationRequest.mockResolvedValue({
+      publicationErrors: [{ tenantId: 'tenant-2' }],
+      publicationResults: [],
+    });
+
+    const { result } = renderHook(() => useSharedRoleValidator(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.validate({ role })).rejects.toThrow(Error);
+    });
+  });
+  it('should throw an error if there are conflicting tenants with duplicate role names', async () => {
+    initPublicationRequest.mockResolvedValue({
+      publicationErrors: [],
+      publicationResults: [
+        { tenantId: 'tenant-1', response: { totalRecords: 1 } },
+        { tenantId: 'tenant-2', response: { totalRecords: 0 } },
+      ],
+    });
+
+    const { result } = renderHook(() => useSharedRoleValidator(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.validate({ role })).rejects.toThrow(Error);
+    });
+  });
+
+  it('should not throw if there are no publication errors or duplicate role names', async () => {
+    initPublicationRequest.mockResolvedValue({
+      publicationErrors: [],
+      publicationResults: [
+        { tenantId: 'tenant-1', response: { totalRecords: 0 } },
+        { tenantId: 'tenant-2', response: { totalRecords: 0 } },
+      ],
+    });
+
+    const { result } = renderHook(() => useSharedRoleValidator(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.validate({ role })).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISAUTHCOM-90

This PR implements role name uniqueness validation across tenants when editing shared authorization roles in a consortia environment. The purpose is to prevent users from sharing authorization roles that have duplicate names in other tenants, which could cause conflicts and data integrity issues across the consortium.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

1. **Validates role uniqueness** by querying all consortium tenants (except the central tenant) for roles with the same name
2. **Handles publication errors gracefully** by checking if any tenant failed to respond to the validation request
3. **Prevents duplicate role names** by filtering for consortium-type roles and throwing an error if conflicts are found
4. **Improves CQL query construction** by using `escapeCqlWildcards` for better security and support for special characters in role names

The validation is now called in two key locations:
- **During initial role sharing**: When users first attempt to share a role from the central tenant
- **During role updates**: When users edit existing shared roles through the `useRoleSharing` hook
