### PR TITLE
[UISAUTHCOM-73] Include capabilities actions when calculating counts for warning when de-selecting an application assigned to a role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [UISAUTHCOM-87](https://folio-org.atlassian.net/browse/UISAUTHCOM-87) OmittheerrantwhitespacethattripsupPluggable's`children`'slengthcalculation.
 * [UISAUTHCOM-83](https://folio-org.atlassian.net/browse/UISAUTHCOM-83) Preserve session-selected capabilities when unchecking a capability set that includes them. Keep `isInitialDataReady` false while fetching data to prevent data from being displayed after the page is reopened.
 * [UISAUTHCOM-90](https://folio-org.atlassian.net/browse/UISAUTHCOM-90) Add validation to ensure role names are unique across tenants when editing shared authorization roles.
+* [UISAUTHCOM-73](https://folio-org.atlassian.net/browse/UISAUTHCOM-73) Include capabilities actions when calculating counts for warning when de-selecting an application assigned to a role.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -126,7 +126,7 @@ export const RoleCreate = ({
 
   const onSubmitSelectApplications = (selectedAppIds, onCloseHandler) => {
     const unselectedAppInfo = changesForUnselect(selectedAppIds, checkedAppIdsMap,
-      capabilities, capabilitySets, selectedCapabilitiesMap, selectedCapabilitySetsMap);
+      capabilities, capabilitySetsList, selectedCapabilitiesMap, selectedCapabilitySetsMap);
 
     if (unselectedAppInfo.isConfirmationNeeded) {
       setUnselectedItemsInfo({ ...unselectedAppInfo, selectedAppIds, onCloseHandler });

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -101,7 +101,7 @@ export const RoleEdit = ({ path, tenantId }) => {
 
   const onSubmitSelectApplications = (selectedAppIds, onCloseHandler) => {
     const unselectedAppInfo = changesForUnselect(selectedAppIds, checkedAppIdsMap,
-      capabilities, capabilitySets, selectedCapabilitiesMap, selectedCapabilitySetsMap);
+      capabilities, capabilitySetsList, selectedCapabilitiesMap, selectedCapabilitySetsMap);
 
     if (unselectedAppInfo.isConfirmationNeeded) {
       setUnselectedItemsInfo({ ...unselectedAppInfo, selectedAppIds, onCloseHandler });

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -231,8 +231,8 @@ export function getCheckboxHandlers({
  * Calculates the number of items (capabilities or capability sets) that would be unselected
  * when certain applications are unselected.
  *
- * @param {Array} unselectedAppIds - Array of application IDs (including version number) that are being unselected.
- * @param {Array} capabilitySetsList - An Array of all capability sets, where each capability set has an `id`, `applicationId`, and `capabilities` (array of capability IDs).
+ * @param {Array<string>} unselectedAppIds - Array of application IDs (including version number) that are being unselected.
+ * @param {Array<object>} capabilitySetsList - An Array of all capability sets, where each capability set has an `id`, `applicationId`, and `capabilities` (array of capability IDs).
  * @param {Object} capabilities - An object where keys are item categories and values are arrays of capabilities, where each capability has an `id`, `applicationId`, and `actions` (object with action names as keys and arrays of capability IDs as values).
  * @param {Object} checkedCapabilitySets - A map indicating which items are currently selected.
  * @param {Object} checkedCapabilities - A map indicating which items are currently selected.
@@ -246,8 +246,10 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
   const unselectedCapabilities = new Set();
   const flatCapabiliesList = Object.entries(capabilities).flatMap(([_, value]) => value);
 
+  // Loop through all checked capabilities and check if they belong to any of the unselected applications. If so, add them to the unselectedCapabilities set.
   for (const checkedCapId of Object.keys(checkedCapabilities)) {
     find(flatCapabiliesList, (cap) => {
+      // Check if the capability belongs to an unselected application and if it is currently selected. If both conditions are true, add it to the unselectedCapabilities set.
       if (unselectedAppIds.find((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
         for (const action in cap.actions) {
           if (cap.actions[action].includes(cap.id)) {
@@ -258,6 +260,7 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
     });
   }
 
+  // Loop through all checked capability sets and check if they belong to any of the unselected applications. If so, add them to the unselectedCapabilitySets set.
   for (const checkedCapSetId of Object.keys(checkedCapabilitySets)) {
     const foundCapSet = find(capabilitySetsList, (capSet) => {
       return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
@@ -267,6 +270,7 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
 
       find(flatCapabiliesList, (cap) => {
         for (const action in cap.actions) {
+          // Check if any capabilities within the unselected capability set are currently selected. If so, add them to the unselectedCapabilities set.
           foundCapSet.capabilities.forEach((subCapId) => {
             if (cap.actions[action].includes(subCapId)) {
               unselectedCapabilities.add(cap.resource + ':' + action);

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -263,14 +263,14 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
   // Loop through all checked capability sets and check if they belong to any of the unselected applications. If so, add them to the unselectedCapabilitySets set.
   for (const checkedCapSetId of Object.keys(checkedCapabilitySets)) {
     const foundCapSet = find(capabilitySetsList, (capSet) => {
-      return capSet.id === checkedCapSetId && unselectedAppIds.some((id) => id === capSet.applicationId);
+      return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
     });
     if (foundCapSet) {
       unselectedCapabilitySets.add(foundCapSet.resource + ':' + foundCapSet.action);
 
       find(flatCapabiliesList, (cap) => {
         for (const action in cap.actions) {
-          if (Object.prototype.hasOwnProperty.call(cap.actions, action)) {
+          if (Object.hasOwn(cap.actions, action)) {
             // Check if any capabilities within the unselected capability set are currently selected. If so, add them to the unselectedCapabilities set.
             foundCapSet.capabilities.forEach((subCapId) => {
               if (cap.actions[action].includes(subCapId)) {

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -265,16 +265,14 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
     if (foundCapSet) {
       unselectedCapabilitySets.add(foundCapSet.resource + ':' + foundCapSet.action);
 
-      foundCapSet.capabilities.forEach((subCap) => {
-        find(flatCapabiliesList, function (cap) {
-          if (cap.id === subCap) {
-            for (const action in cap.actions) {
-                if (cap.actions[action].includes(cap.id)) {
-                    unselectedCapabilities.add(cap.resource + ':' + action);
-                }
+      find(flatCapabiliesList, function (cap) {
+        for (const action in cap.actions) {
+          foundCapSet.capabilities.forEach((subCapId) => {
+            if (cap.actions[action].includes(subCapId)) {
+                unselectedCapabilities.add(cap.resource + ':' + action);
             }
-          }
-        });
+          });
+        }
       });
     }
   }

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -1,4 +1,4 @@
-import { difference, find, findKey } from 'lodash';
+import { difference, find } from 'lodash';
 
 import { getUnversionedAppId } from '../utils/helpers';
 
@@ -247,29 +247,29 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
   const flatCapabiliesList = Object.entries(capabilities).flatMap(([_, value]) => value);
 
   for (const checkedCapId of Object.keys(checkedCapabilities)) {
-    find(flatCapabiliesList, function (cap) {
-        if (unselectedAppIds.find((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
-            for (const action in cap.actions) {
-                if (cap.actions[action].includes(cap.id)) {
-                    unselectedCapabilities.add(cap.resource + ':' + action);
-                }
-            }
+    find(flatCapabiliesList, (cap) => {
+      if (unselectedAppIds.find((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
+        for (const action in cap.actions) {
+          if (cap.actions[action].includes(cap.id)) {
+            unselectedCapabilities.add(cap.resource + ':' + action);
+          }
         }
+      }
     });
   }
 
   for (const checkedCapSetId of Object.keys(checkedCapabilitySets)) {
-    const foundCapSet = find(capabilitySetsList, function (capSet) {
-        return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
+    const foundCapSet = find(capabilitySetsList, (capSet) => {
+      return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
     });
     if (foundCapSet) {
       unselectedCapabilitySets.add(foundCapSet.resource + ':' + foundCapSet.action);
 
-      find(flatCapabiliesList, function (cap) {
+      find(flatCapabiliesList, (cap) => {
         for (const action in cap.actions) {
           foundCapSet.capabilities.forEach((subCapId) => {
             if (cap.actions[action].includes(subCapId)) {
-                unselectedCapabilities.add(cap.resource + ':' + action);
+              unselectedCapabilities.add(cap.resource + ':' + action);
             }
           });
         }

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -250,7 +250,7 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
   for (const checkedCapId of Object.keys(checkedCapabilities)) {
     find(flatCapabiliesList, (cap) => {
       // Check if the capability belongs to an unselected application and if it is currently selected. If both conditions are true, add it to the unselectedCapabilities set.
-      if (unselectedAppIds.find((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
+      if (unselectedAppIds.some((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
         for (const action in cap.actions) {
           if (cap.actions[action].includes(cap.id)) {
             unselectedCapabilities.add(cap.resource + ':' + action);
@@ -263,19 +263,21 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, ca
   // Loop through all checked capability sets and check if they belong to any of the unselected applications. If so, add them to the unselectedCapabilitySets set.
   for (const checkedCapSetId of Object.keys(checkedCapabilitySets)) {
     const foundCapSet = find(capabilitySetsList, (capSet) => {
-      return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
+      return capSet.id === checkedCapSetId && unselectedAppIds.some((id) => id === capSet.applicationId);
     });
     if (foundCapSet) {
       unselectedCapabilitySets.add(foundCapSet.resource + ':' + foundCapSet.action);
 
       find(flatCapabiliesList, (cap) => {
         for (const action in cap.actions) {
-          // Check if any capabilities within the unselected capability set are currently selected. If so, add them to the unselectedCapabilities set.
-          foundCapSet.capabilities.forEach((subCapId) => {
-            if (cap.actions[action].includes(subCapId)) {
-              unselectedCapabilities.add(cap.resource + ':' + action);
-            }
-          });
+          if (Object.prototype.hasOwnProperty.call(cap.actions, action)) {
+            // Check if any capabilities within the unselected capability set are currently selected. If so, add them to the unselectedCapabilities set.
+            foundCapSet.capabilities.forEach((subCapId) => {
+              if (cap.actions[action].includes(subCapId)) {
+                unselectedCapabilities.add(cap.resource + ':' + action);
+              }
+            });
+          }
         }
       });
     }

--- a/lib/Role/utils.js
+++ b/lib/Role/utils.js
@@ -1,4 +1,4 @@
-import { difference } from 'lodash';
+import { difference, find, findKey } from 'lodash';
 
 import { getUnversionedAppId } from '../utils/helpers';
 
@@ -232,38 +232,50 @@ export function getCheckboxHandlers({
  * when certain applications are unselected.
  *
  * @param {Array} unselectedAppIds - Array of application IDs (including version number) that are being unselected.
- * @param {Object} capabilitySets - An object where keys are item categories and values are arrays of items.
+ * @param {Array} capabilitySetsList - An Array of all capability sets, where each capability set has an `id`, `applicationId`, and `capabilities` (array of capability IDs).
+ * @param {Object} capabilities - An object where keys are item categories and values are arrays of capabilities, where each capability has an `id`, `applicationId`, and `actions` (object with action names as keys and arrays of capability IDs as values).
  * @param {Object} checkedCapabilitySets - A map indicating which items are currently selected.
- * @param {Object} capabilities - An object where keys are item categories and values are arrays of items.
  * @param {Object} checkedCapabilities - A map indicating which items are currently selected.
  *
  * @returns {Object} An object containing two sets:
  * - `unselectedCapabilitySetCount`: The count of capability sets that would be unselected.
  * - `unselectedCapabilityCount`: The count of capabilities that would be unselected.
  */
-export function getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities) {
+export function getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, capabilities, checkedCapabilitySets, checkedCapabilities) {
   const unselectedCapabilitySets = new Set();
   const unselectedCapabilities = new Set();
-
-  const flatCapabilitySetsList = Object.entries(capabilitySets).flatMap(([_, value]) => value);
   const flatCapabiliesList = Object.entries(capabilities).flatMap(([_, value]) => value);
-  const flatList = flatCapabilitySetsList.concat(flatCapabiliesList);
 
-  for (const item of flatList) {
-    for (const versionedAppId of unselectedAppIds) {
-      if (item.applicationId === getUnversionedAppId(versionedAppId)) {
-        if (checkedCapabilitySets[item.id]) {
-          unselectedCapabilitySets.add(item.id);
+  for (const checkedCapId of Object.keys(checkedCapabilities)) {
+    find(flatCapabiliesList, function (cap) {
+        if (unselectedAppIds.find((id) => getUnversionedAppId(id) === cap.applicationId) && Object.values(cap.actions).includes(checkedCapId)) {
+            for (const action in cap.actions) {
+                if (cap.actions[action].includes(cap.id)) {
+                    unselectedCapabilities.add(cap.resource + ':' + action);
+                }
+            }
+        }
+    });
+  }
 
-          // Capability sets have child capabilities should be counted as they are unselected too
-          for (const capId of item.capabilities) {
-            unselectedCapabilities.add(capId);
+  for (const checkedCapSetId of Object.keys(checkedCapabilitySets)) {
+    const foundCapSet = find(capabilitySetsList, function (capSet) {
+        return capSet.id === checkedCapSetId && unselectedAppIds.find((id) => id === capSet.applicationId);
+    });
+    if (foundCapSet) {
+      unselectedCapabilitySets.add(foundCapSet.resource + ':' + foundCapSet.action);
+
+      foundCapSet.capabilities.forEach((subCap) => {
+        find(flatCapabiliesList, function (cap) {
+          if (cap.id === subCap) {
+            for (const action in cap.actions) {
+                if (cap.actions[action].includes(cap.id)) {
+                    unselectedCapabilities.add(cap.resource + ':' + action);
+                }
+            }
           }
-        }
-        if (checkedCapabilities[item.id]) { // It's a capability
-          unselectedCapabilities.add(item.id);
-        }
-      }
+        });
+      });
     }
   }
 
@@ -277,7 +289,7 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabi
  * @param {Object} selectedAppIds - Map of currently selected application IDs.
  * @param {Object} checkedAppIdsMap - Map of all checked application IDs.
  * @param {Object} capabilities - Object containing capabilities categorized by application ID.
- * @param {Object} capabilitySets - Object containing capability sets categorized by application ID.
+ * @param {Object} capabilitySetsList - An Array of all capability sets, where each capability set has an `id`, `applicationId`, and `capabilities` (array of capability IDs).
  * @param {Object} selectedCapabilitiesMap - Map of currently selected capabilities.
  * @param {Object} selectedCapabilitySetsMap - Map of currently selected capability sets.
  *
@@ -288,12 +300,12 @@ export function getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabi
  * - `unselectedCapabilityCount`: Count of capabilities that would be unselected.
  * - `unselectedCapabilitySetCount`: Count of capability sets that would be unselected.
  */
-export function changesForUnselect(selectedAppIds, checkedAppIdsMap, capabilities, capabilitySets, selectedCapabilitiesMap, selectedCapabilitySetsMap) {
+export function changesForUnselect(selectedAppIds, checkedAppIdsMap, capabilities, capabilitySetsList, selectedCapabilitiesMap, selectedCapabilitySetsMap) {
   let isConfirmationNeeded = false;
   const unselectedAppIds = difference(Object.keys(checkedAppIdsMap), Object.keys(selectedAppIds));
 
   if (unselectedAppIds.length) {
-    const unselectedCapabilities = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, selectedCapabilitySetsMap, selectedCapabilitiesMap);
+    const unselectedCapabilities = getUnselectedItemCounts(unselectedAppIds, capabilitySetsList, capabilities, selectedCapabilitySetsMap, selectedCapabilitiesMap);
 
     // If there are any capabilities or capability sets that would be unselected, show confirmation modal
     if (unselectedCapabilities.unselectedCapabilitySetCount > 0 || unselectedCapabilities.unselectedCapabilityCount > 0) {

--- a/lib/Role/utils.test.js
+++ b/lib/Role/utils.test.js
@@ -8,6 +8,7 @@ describe('useCheckboxHandlers', () => {
   let selectedCapabilitiesMap;
   let setSelectedCapabilitiesMap;
   let capabilitySetsList;
+  let capabilities;
   let setDisabledCapabilities;
   let selectedCapabilitySetsMap;
   let setSelectedCapabilitySetsMap;
@@ -18,6 +19,40 @@ describe('useCheckboxHandlers', () => {
   beforeEach(() => {
     selectedCapabilitiesMap = { '5a0d6531-533c-4f48-a9a6-93e266ebd28a': true };
     setSelectedCapabilitiesMap = jest.fn();
+    capabilities = {
+      'data': [
+        {
+          'id': 'cap1_create',
+          'resource': 'Cap 1',
+          'applicationId': 'app-1',
+          'actions': {
+            'create': 'cap1_create',
+            'view': 'cap1_view',
+            'edit': 'cap1_edit',
+            'delete': 'cap1_delete',
+            'manage': 'cap1_manage'
+          }
+        },
+        {
+          'id': 'cap2_view',
+          'resource': 'Cap 2',
+          'applicationId': 'app-2',
+          'actions': {
+            'view': 'cap2_view',
+            'manage': 'cap2_manage'
+          }
+        },
+        {
+          'id': 'cap3_view',
+          'resource': 'Cap 3',
+          'applicationId': 'app-3',
+          'actions': {
+            'view': 'cap3_view',
+            'manage': 'cap3_manage'
+          }
+        }
+      ]
+    };
     capabilitySetsList = [
       {
         'id': 'b7cbae7f-5d7a-4af5-bd4e-f70ad245ba2c',
@@ -291,17 +326,10 @@ describe('useCheckboxHandlers', () => {
 
   describe('getUnselectedItemCounts', () => {
     it('returns zero counts when no items match unselected app ids', () => {
-      const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupA: [
-          { id: 'setA', applicationId: 'app-2', capabilities: ['cap1'] },
-        ],
-      };
-      const capabilities = {
-        groupB: [
-          { id: 'capB', applicationId: 'app-2' },
-        ],
-      };
+      const unselectedAppIds = ['99'];
+      const capabilitySets = [
+        { id: 'setZ', resource: 'Set Z', action: 'view', applicationId: '2', capabilities: ['cap1_view'] },
+      ];
       const checkedCapabilitySets = {};
       const checkedCapabilities = {};
 
@@ -312,83 +340,61 @@ describe('useCheckboxHandlers', () => {
 
     it('counts unselected capability sets with their child capabilities', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupA: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1', 'cap2'] },
-        ],
-      };
-      const capabilities = {};
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: '1', capabilities: ['cap1_view', 'cap2_view'] },
+      ];
       const checkedCapabilitySets = { setA: true };
-      const checkedCapabilities = { cap1: true, cap2: true };
+      const checkedCapabilities = { cap1_view: true, cap2_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 2 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 3 });
     });
 
     it('counts only checked capabilities when capability set is unchecked', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupA: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1', 'cap2'] },
-        ],
-      };
-      const capabilities = {};
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: '1', capabilities: ['cap1_view', 'cap2_view'] },
+      ];
       const checkedCapabilitySets = {};
-      const checkedCapabilities = { cap1: true };
+      const checkedCapabilities = { cap1_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 0, unselectedCapabilityCount: 0 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 0, unselectedCapabilityCount: 1 });
     });
 
     it('counts capabilities only once if duplicates are present', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupSets: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1', 'cap2'] },
-          { id: 'setB', applicationId: 'app-1', capabilities: ['cap1', 'cap2'] },
-        ],
-      };
-      const capabilities = {};
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: '1', capabilities: ['cap1_view', 'cap2_view'] },
+        { id: 'setB', resource: 'Set B', action: 'view', applicationId: '2', capabilities: ['cap1_view', 'cap2_view'] },
+      ];
       const checkedCapabilitySets = { setA: true };
-      const checkedCapabilities = { cap1: true, cap2: true };
+      const checkedCapabilities = { cap1_view: true, cap2_view: true };
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 2 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 3 });
     });
 
     it('counts unselected standalone capabilities', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {};
-      const capabilities = {
-        groupA: [
-          { id: 'capA', applicationId: 'app-1' },
-          { id: 'capB', applicationId: 'app-1' },
-        ],
-      };
+      const capabilitySets = [];
       const checkedCapabilitySets = {};
-      const checkedCapabilities = { capA: true, capB: true };
+      const checkedCapabilities = { cap1_view: true, cap2_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 0, unselectedCapabilityCount: 2 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 0, unselectedCapabilityCount: 1 });
     });
 
     it('handles mixed capability sets and capabilities', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupSets: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1'] },
-        ],
-      };
-      const capabilities = {
-        groupCaps: [
-          { id: 'capB', applicationId: 'app-1' },
-        ],
-      };
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: '1', capabilities: ['cap1_view'] },
+      ];
       const checkedCapabilitySets = { setA: true };
-      const checkedCapabilities = { cap1: true, capB: true };
+      const checkedCapabilities = { cap1_view: true, cap2_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
@@ -397,55 +403,49 @@ describe('useCheckboxHandlers', () => {
 
     it('handles multiple unselected app ids', () => {
       const unselectedAppIds = ['1', '2'];
-      const capabilitySets = {
-        groupA: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1'] },
-          { id: 'setB', applicationId: 'app-2', capabilities: ['cap2'] },
-        ],
-      };
-      const capabilities = {};
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: '1', capabilities: ['cap1_view'] },
+        { id: 'setB', resource: 'Set B', action: 'view', applicationId: '2', capabilities: ['cap2_view'] }
+      ];
       const checkedCapabilitySets = { setA: true, setB: true };
-      const checkedCapabilities = { cap1: true, cap2: true };
+      const checkedCapabilities = { cap1_view: true, cap2_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 2, unselectedCapabilityCount: 2 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 2, unselectedCapabilityCount: 3 });
     });
 
     it('does not count unchecked child capabilities of checked capability set', () => {
       const unselectedAppIds = ['1'];
-      const capabilitySets = {
-        groupA: [
-          { id: 'setA', applicationId: 'app-1', capabilities: ['cap1', 'cap2'] },
-        ],
-      };
-      const capabilities = {};
+      const capabilitySets = [
+        { id: 'setA', applicationId: '1', capabilities: ['cap1_view', 'cap2_view'] },
+      ];
       const checkedCapabilitySets = { setA: true };
-      const checkedCapabilities = { cap1: true };
+      const checkedCapabilities = { cap1_view: true };
 
       const result = getUnselectedItemCounts(unselectedAppIds, capabilitySets, capabilities, checkedCapabilitySets, checkedCapabilities);
 
-      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 2 });
+      expect(result).toEqual({ unselectedCapabilitySetCount: 1, unselectedCapabilityCount: 3 });
     });
   });
 
   describe('determineIfConfirmationNeededForUnselectedApps', () => {
     it('returns isConfirmationNeeded false when there are no unselected apps', () => {
-      const selectedAppIds = { '1': true };
-      const checkedAppIdsMap = { '1': true };
-      const capabilities = {
+      const selectedAppIds = { 'app-1': true };
+      const checkedAppIdsMap = { 'app-1': true };
+      const localCapabilities = {
         groupA: [
           { id: 'capA', applicationId: 'app-1' },
         ],
       };
-      const capabilitySets = {};
+      const capabilitySets = [];
       selectedCapabilitiesMap = { capA: true };
       selectedCapabilitySetsMap = {};
 
       const result = changesForUnselect(
         selectedAppIds,
         checkedAppIdsMap,
-        capabilities,
+        localCapabilities,
         capabilitySets,
         selectedCapabilitiesMap,
         selectedCapabilitySetsMap,
@@ -455,9 +455,9 @@ describe('useCheckboxHandlers', () => {
     });
 
     it('returns isConfirmationNeeded false when unselected apps do not cause any selected items to be unselected', () => {
-      const selectedAppIds = { '1': true };
-      const checkedAppIdsMap = { '1': true, '2': true }; // '2' is unselected
-      const capabilities = {
+      const selectedAppIds = { 'app-1': true };
+      const checkedAppIdsMap = { 'app-1': true, 'app-2': true }; // '2' is unselected
+      const localCapabilities = {
         groupA: [
           { id: 'capA', applicationId: 'app-1' },
         ],
@@ -468,12 +468,12 @@ describe('useCheckboxHandlers', () => {
         ],
       };
       selectedCapabilitiesMap = { capA: true };
-      selectedCapabilitySetsMap = { 'set-1': true };
+      selectedCapabilitySetsMap = { 'setA': true };
 
       const result = changesForUnselect(
         selectedAppIds,
         checkedAppIdsMap,
-        capabilities,
+        localCapabilities,
         capabilitySets,
         selectedCapabilitiesMap,
         selectedCapabilitySetsMap,
@@ -483,18 +483,11 @@ describe('useCheckboxHandlers', () => {
     });
 
     it('returns detailed result with capability sets when unselected apps have capability sets', () => {
-      const selectedAppIds = { '1': true };
-      const checkedAppIdsMap = { '1': true, '2': true };
-      const capabilities = {
-        groupA: [
-          { id: 'capA', applicationId: 'app-1' },
-        ],
-      };
-      const capabilitySets = {
-        groupSets: [
-          { id: 'setA', applicationId: 'app-2', capabilities: ['cap1', 'cap2'] },
-        ],
-      };
+      const selectedAppIds = { 'app-1': true };
+      const checkedAppIdsMap = { 'app-1': true, 'app-2': true };
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: 'app-2', capabilities: ['cap1', 'cap2'] },
+      ];
       selectedCapabilitiesMap = { capA: true };
       selectedCapabilitySetsMap = { setA: true };
 
@@ -508,31 +501,27 @@ describe('useCheckboxHandlers', () => {
       );
 
       expect(result.isConfirmationNeeded).toBe(true);
-      expect(result.unselectedAppIds).toContain('2');
+      expect(result.unselectedAppIds).toContain('app-2');
       expect(result.unselectedCapabilitySetCount).toBe(1);
-      expect(result.unselectedCapabilityCount).toBe(2);
+      expect(result.unselectedCapabilityCount).toBe(7);
     });
 
     it('returns isConfirmationNeeded false when unselected capabilities and sets are not checked', () => {
-      const selectedAppIds = { '1': true };
-      const checkedAppIdsMap = { '1': true, '2': true };
-      const capabilities = {
-        groupA: [
-          { id: 'capA', applicationId: 'app-2' },
-        ],
-      };
-      const capabilitySets = {
-        groupSets: [
-          { id: 'setA', applicationId: 'app-2' },
-        ],
-      };
-      selectedCapabilitiesMap = { capA: false };
-      selectedCapabilitySetsMap = { setA: false };
+      const selectedAppIds = { 'app-1': true };
+      const checkedAppIdsMap = { 'app-1': true, 'app-2': true };
+      const localCapabilities = [
+        { id: 'capA', applicationId: 'app-2' },
+      ];
+      const capabilitySets = [
+        { id: 'setA', resource: 'Set A', action: 'view', applicationId: 'app-2' },
+      ];
+      selectedCapabilitiesMap = {};
+      selectedCapabilitySetsMap = {};
 
       const result = changesForUnselect(
         selectedAppIds,
         checkedAppIdsMap,
-        capabilities,
+        localCapabilities,
         capabilitySets,
         selectedCapabilitiesMap,
         selectedCapabilitySetsMap,
@@ -541,17 +530,11 @@ describe('useCheckboxHandlers', () => {
       expect(result.isConfirmationNeeded).toBe(false);
     });
 
-    it('handles multiple unselected apps correctly', () => {
-      const selectedAppIds = { '1': true };
-      const checkedAppIdsMap = { '1': true, '2': true, '3': true };
-      const capabilities = {
-        groupA: [
-          { id: 'capA', applicationId: 'app-2' },
-          { id: 'capB', applicationId: 'app-3' },
-        ],
-      };
-      const capabilitySets = {};
-      selectedCapabilitiesMap = { capA: true, capB: true };
+    it.skip('handles multiple unselected apps correctly', () => { // TODO: fix
+      const selectedAppIds = { 'app-3': true };
+      const checkedAppIdsMap = { 'app-1': true, 'app-2': true, 'app-3': true };
+      const capabilitySets = [];
+      selectedCapabilitiesMap = { cap1_view: true, cap2_view: true };
       selectedCapabilitySetsMap = {};
 
       const result = changesForUnselect(
@@ -564,8 +547,8 @@ describe('useCheckboxHandlers', () => {
       );
 
       expect(result.isConfirmationNeeded).toBe(true);
-      expect(result.unselectedAppIds).toContain('2');
-      expect(result.unselectedAppIds).toContain('3');
+      expect(result.unselectedAppIds).toContain('app-2');
+      expect(result.unselectedAppIds).toContain('app-3');
       expect(result.unselectedCapabilityCount).toBe(2);
     });
 

--- a/lib/Role/utils.test.js
+++ b/lib/Role/utils.test.js
@@ -530,9 +530,9 @@ describe('useCheckboxHandlers', () => {
       expect(result.isConfirmationNeeded).toBe(false);
     });
 
-    it.skip('handles multiple unselected apps correctly', () => { // TODO: fix
-      const selectedAppIds = { 'app-3': true };
-      const checkedAppIdsMap = { 'app-1': true, 'app-2': true, 'app-3': true };
+    it('handles multiple unselected apps correctly', () => {
+      const selectedAppIds = { '3': true };
+      const checkedAppIdsMap = { '1': true, '2': true, '3': true };
       const capabilitySets = [];
       selectedCapabilitiesMap = { cap1_view: true, cap2_view: true };
       selectedCapabilitySetsMap = {};
@@ -547,8 +547,7 @@ describe('useCheckboxHandlers', () => {
       );
 
       expect(result.isConfirmationNeeded).toBe(true);
-      expect(result.unselectedAppIds).toContain('app-2');
-      expect(result.unselectedAppIds).toContain('app-3');
+      expect(result.unselectedAppIds).toEqual(expect.arrayContaining(['1', '2']));
       expect(result.unselectedCapabilityCount).toBe(2);
     });
 


### PR DESCRIPTION
- Fixes count issue reported by QA in [UISAUTHCOM-73](https://folio-org.atlassian.net/browse/UISAUTHCOM-73?focusedCommentId=286951).
- Previously, counting was not considering capability action IDs. It was only counting the parent ID, which matches the first action ID, but not the others. So if an action doesn't happen to match the parent ID, it is not counted. Now, all action IDs are considered, creating an accurate count in all cases.
- A different object was needed to be passed in to accomplish this mapping. `capabilitySets` was too simple and did not contain the full action mapping. `capabilitySetsLists` contains the correct mapping so we can determine matching action IDs.


https://github.com/user-attachments/assets/974e053c-8552-4356-8f2c-3bc10636b1f2

