### PR TITLE
[UISAUTHCOM-93] Send full object body in PUT /roles request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [UISAUTHCOM-87](https://folio-org.atlassian.net/browse/UISAUTHCOM-87) OmittheerrantwhitespacethattripsupPluggable's`children`'slengthcalculation.
 * [UISAUTHCOM-83](https://folio-org.atlassian.net/browse/UISAUTHCOM-83) Preserve session-selected capabilities when unchecking a capability set that includes them. Keep `isInitialDataReady` false while fetching data to prevent data from being displayed after the page is reopened.
 * [UISAUTHCOM-90](https://folio-org.atlassian.net/browse/UISAUTHCOM-90) Add validation to ensure role names are unique across tenants when editing shared authorization roles.
+* [UISAUTHCOM-93](https://folio-org.atlassian.net/browse/UISAUTHCOM-93) Send full object body in PUT /roles request.
 
 # [2.0.2](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.2)
 

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -162,6 +162,8 @@ export const RoleEdit = ({ path, tenantId }) => {
 
   const roleData = {
     id: roleId,
+    type: roleDetails?.type,
+    metadata: roleDetails?.metadata,
     name: roleName,
     description,
   };

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -257,6 +257,35 @@ describe('RoleEdit', () => {
     expect(getByTestId('pluggable-select-application')).toBeInTheDocument();
   });
 
+  it('should pass role metadata to useEditRoleMutation', () => {
+    const metadata = {
+      version: 1,
+      createdDate: '2024-01-01',
+      createdByUserId: 'user1',
+      updatedDate: '2024-01-02',
+      updatedByUserId: 'user2',
+    };
+
+    useRoleById.mockReturnValue({
+      roleDetails: {
+        id: '1',
+        type: 'REGULAR',
+        name: 'Admin',
+        description: 'Description',
+        metadata,
+      },
+      isSuccess: true,
+    });
+
+    renderComponent();
+
+    expect(useEditRoleMutation).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it('should call capability/sets to local state on initial loading page, i.e. in useEffect', async () => {
     const { getAllByRole } = renderComponent();
 

--- a/lib/hooks/useEditRoleMutation/useEditRoleMutation.js
+++ b/lib/hooks/useEditRoleMutation/useEditRoleMutation.js
@@ -4,7 +4,7 @@ import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 import { ROLES_REQUEST_TIMEOUT } from '../../constants';
 
 export const useEditRoleMutation = (
-  { id, name, description },
+  { id, type, metadata, name, description },
   { roleCapabilitiesListIds, shouldUpdateCapabilities, shouldUpdateCapabilitySets, roleCapabilitySetsListIds },
   { handleError, tenantId }
 ) => {
@@ -12,7 +12,7 @@ export const useEditRoleMutation = (
   const queryClient = useQueryClient();
   const [namespace] = useNamespace();
   const { mutateAsync, isLoading } = useMutation({
-    mutationFn: () => ky.put(`roles/${id}`, { json: { name, description } }).json(),
+    mutationFn: () => ky.put(`roles/${id}`, { json: { type, metadata, name, description } }).json(),
     onSuccess: async () => {
       if (shouldUpdateCapabilities) {
         await ky.put(`roles/${id}/capabilities`, { json: { capabilityIds: roleCapabilitiesListIds } });

--- a/lib/hooks/useEditRoleMutation/useEditRoleMutation.test.js
+++ b/lib/hooks/useEditRoleMutation/useEditRoleMutation.test.js
@@ -21,13 +21,21 @@ describe('useEditRoleMutation', () => {
       put: putMock,
     });
 
+    const metadata = { version: 1, createdDate: '2024-01-01', createdByUserId: 'user1', updatedDate: '2024-01-01', updatedByUserId: 'user1' };
+
     const { result } = renderHook(
-      () => useEditRoleMutation({ id:'1', description: 'description', name: 'name' }, ['1', '2', '3'], { handleError: jest.fn() }),
+      () => useEditRoleMutation({ id:'1', type: 'REGULAR', metadata, description: 'description', name: 'name' }, ['1', '2', '3'], { handleError: jest.fn() }),
       { wrapper },
     );
 
     await act(async () => { result.current.mutateRole(); });
 
-    expect(putMock).toHaveBeenCalled();
+    expect(putMock).toHaveBeenCalledWith('roles/1', {
+      json: expect.objectContaining({
+        metadata: expect.objectContaining({
+          version: metadata.version,
+        }),
+      }),
+    });
   });
 });


### PR DESCRIPTION
- Fulfills [UISAUTHCOM-93](https://folio-org.atlassian.net/browse/UISAUTHCOM-93).
- Simply added fields `type` and `metadata` as requested by the ticket to complete the full object.