### PR TITLE
[UIROLES-170] Allow `Save` button to be enabled after first character entered in required `Role Name` field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UISAUTHCOM-73](https://folio-org.atlassian.net/browse/UISAUTHCOM-73) Include capabilities actions when calculating counts for warning when de-selecting an application assigned to a role.
 * [UISAUTHCOM-93](https://folio-org.atlassian.net/browse/UISAUTHCOM-93) Send full object body in PUT /roles request.
+* [UIROLES-170](https://folio-org.atlassian.net/browse/UIROLES-170) Allow Save button to be enabled after first character entered in required `Role Name` field.
 
 # [2.1.0](https://github.com/folio-org/stripes-authorization-components/tree/v2.1.0)
 

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -114,7 +114,7 @@ export const RoleForm = ({
                   required
                   value={roleName}
                   label={<FormattedMessage id="stripes-authorization-components.form.labels.name" />}
-                  onBlur={event => setRoleName(event.target.value)}
+                  onChange={event => setRoleName(event.target.value)}
                   data-testid="rolename-input"
                 />
                 <TextArea


### PR DESCRIPTION
- Fixes [UIROLES-170](https://folio-org.atlassian.net/browse/UIROLES-170).
- Previous `onBlur` event only fired after user moved focus away from `Role Name` text field. `onChange` allows `Save` state to change on first character entered or last character deleted.