### PR TITLE
UISAUTHCOM-98 - convert to SessionConfirmationModal in RoleForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [UISAUTHCOM-73](https://folio-org.atlassian.net/browse/UISAUTHCOM-73) Include capabilities actions when calculating counts for warning when de-selecting an application assigned to a role.
 * [UISAUTHCOM-93](https://folio-org.atlassian.net/browse/UISAUTHCOM-93) Send full object body in PUT /roles request.
 * [UIROLES-170](https://folio-org.atlassian.net/browse/UIROLES-170) Allow Save button to be enabled after first character entered in required `Role Name` field.
-* [UISAUTHCOM-98](https://folio-org.atlassian.net/browse/UISAUTHCOM-98) Display warning and require confirmation before unchecking a capability set.
+* [UISAUTHCOM-98](https://folio-org.atlassian.net/browse/UISAUTHCOM-98) Display warning and require confirmation before unchecking a capability set. Modals will allow for suppression for the rest of the session.
 
 # [2.1.0](https://github.com/folio-org/stripes-authorization-components/tree/v2.1.0)
 
@@ -82,7 +82,7 @@
 * [UISAUTHCOM-12](https://folio-org.atlassian.net/browse/UISAUTHCOM-12) Ensure support for the passed `tenantId` value for manipulations in the context of a specific tenant.
 * [UISAUTHCOM-17](https://folio-org.atlassian.net/browse/UISAUTHCOM-17) Create reusable components for editing, saving Authorization policies for the consortium.
 * [UISAUTHCOM-15](https://folio-org.atlassian.net/browse/UISAUTHCOM-15) Check if user exists in Keycloak on assign users to role. If not show confirmation dialog to create user records in Keycloak.
-* [UISAUTHCOM-18](https://folio-org.atlassian.net/browse/UISAUTHCOM-18) Add button to unassign all assigned capabilities/sets when editing an authorization role in RoleForm. 
+* [UISAUTHCOM-18](https://folio-org.atlassian.net/browse/UISAUTHCOM-18) Add button to unassign all assigned capabilities/sets when editing an authorization role in RoleForm.
 * [UISAUTHCOM-19](https://folio-org.atlassian.net/browse/UISAUTHCOM-19) Create reusable hooks and components for duplicate authorization role.
 * [UISAUTHCOM-22](https://folio-org.atlassian.net/browse/UISAUTHCOM-22) Move "Select application" button to the top of the role form
 * [UISAUTHCOM-14](https://folio-org.atlassian.net/browse/UISAUTHCOM-14) ECS - Support sharing of authorization roles and policies.

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -6,7 +6,7 @@ import {
   Accordion,
   AccordionSet,
   AccordionStatus, Button,
-  ConfirmationModal,
+  SessionConfirmationModal,
   ExpandAllButton,
   Layer,
   Pane,
@@ -216,10 +216,10 @@ export const RoleForm = ({
                   </Button>
                 )}
               ><FormattedMessage
-                id="stripes-authorization-components.applications.notAvailable"
-              />
+                  id="stripes-authorization-components.applications.notAvailable"
+                />
               </Pluggable>
-              <ConfirmationModal
+              <SessionConfirmationModal
                 id="unselect-application-confirmation-modal"
                 open={isUnselectApplicationConfirmationOpen}
                 onConfirm={() => {
@@ -238,8 +238,9 @@ export const RoleForm = ({
                   }}
                 />}
                 confirmLabel={<FormattedMessage id="stripes-core.button.continue" />}
+                sessionKey="suppress-authroles-unselect-confirmation-modal"
               />
-              <ConfirmationModal
+              <SessionConfirmationModal
                 id="unselect-capability-set-confirmation-modal"
                 open={isUnselectCapabilitySetConfirmationOpen.open}
                 onConfirm={() => {
@@ -264,6 +265,7 @@ export const RoleForm = ({
                   }}
                 />}
                 confirmLabel={<FormattedMessage id="stripes-core.button.continue" />}
+                sessionKey="suppress-authroles-unselect-confirmation-modal"
               />
 
               {!!unselectAllCapabilitiesAndSets && <Button

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -215,7 +215,8 @@ export const RoleForm = ({
                     />
                   </Button>
                 )}
-              ><FormattedMessage
+              >
+                <FormattedMessage
                   id="stripes-authorization-components.applications.notAvailable"
                 />
               </Pluggable>

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -260,7 +260,7 @@ export const RoleForm = ({
                   }}
                 />}
                 confirmLabel={<FormattedMessage id="stripes-core.button.continue" />}
-                sessionKey="suppress-authroles-unselect-confirmation-modal"
+                sessionKey="suppress-deselect-application-confirmation-modal"
               />
               <SessionConfirmationModal
                 id="unselect-capability-set-confirmation-modal"
@@ -287,7 +287,7 @@ export const RoleForm = ({
                   }}
                 />}
                 confirmLabel={<FormattedMessage id="stripes-core.button.continue" />}
-                sessionKey="suppress-authroles-unselect-confirmation-modal"
+                sessionKey="suppress-authroles-deselect-confirmation-modal"
               />
 
               {!!unselectAllCapabilitiesAndSets && <Button

--- a/lib/Role/RoleForm/RoleForm.test.js
+++ b/lib/Role/RoleForm/RoleForm.test.js
@@ -1,3 +1,4 @@
+import { FormattedMessage } from 'react-intl';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import {
   fireEvent,
@@ -5,7 +6,6 @@ import {
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
 
-import { ConfirmationModal } from '@folio/stripes/components';
 import { mockPluggableOnClose } from '@folio/stripes/core';
 
 import { RoleForm } from './RoleForm';
@@ -150,8 +150,11 @@ const renderComponent = (props = {}) => render(
   />
 );
 
-const getConfirmationModalProps = (id) => {
-  const matchingCalls = ConfirmationModal.mock.calls.filter(([props]) => props.id === id);
+// SessionConfirmationModal renders the real (unmocked) ConfirmationModal/Modal internally, so its
+// `message` prop (a <FormattedMessage />) can't be inspected via a mocked ConfirmationModal. Instead,
+// pull the values passed to the mocked `FormattedMessage` for a given translation id.
+const getFormattedMessageProps = (id) => {
+  const matchingCalls = FormattedMessage.mock.calls.filter(([props]) => props.id === id);
 
   return matchingCalls[matchingCalls.length - 1][0];
 };
@@ -160,6 +163,7 @@ describe('RoleForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPluggableOnClose.mockClear();
+    sessionStorage.clear();
   });
 
   it('renders the form with editable role information and footer actions', async () => {
@@ -226,10 +230,8 @@ describe('RoleForm', () => {
       },
     });
 
-    const modalProps = getConfirmationModalProps('unselect-application-confirmation-modal');
-
-    expect(modalProps.open).toBe(true);
-    expect(modalProps.message.props.values).toEqual({
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(getFormattedMessageProps('stripes-authorization-components.applications.unselect.warning').values).toEqual({
       appNames: 'app-1',
       capabilitiesCount: 2,
       capabilitySetsCount: 1,
@@ -254,7 +256,7 @@ describe('RoleForm', () => {
       },
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'stripes-components.cancel' }));
 
     expect(defaultProps.setIsUnselectApplicationConfirmationOpen).toHaveBeenCalledWith(false);
     expect(defaultProps.applyAppIdsChanges).not.toHaveBeenCalled();
@@ -273,10 +275,8 @@ describe('RoleForm', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'uncheck capability set' }));
 
-    const modalProps = getConfirmationModalProps('unselect-capability-set-confirmation-modal');
-
-    expect(modalProps.open).toBe(true);
-    expect(modalProps.message.props.values).toEqual({
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(getFormattedMessageProps('stripes-authorization-components.capabilitySets.unselect.warning').values).toEqual({
       capabilitySet: 'Invoices - view',
       capabilitiesCount: 1,
     });
@@ -285,6 +285,28 @@ describe('RoleForm', () => {
 
     expect(defaultProps.onChangeCapabilitySetCheckbox).toHaveBeenCalledWith(false, 'cap-set-1');
     expect(defaultProps.toggleCapabilitySetsHeaderCheckbox).not.toHaveBeenCalled();
+  });
+
+  it('does not show the confirmation modal again after checking "do not display this message again" and confirming', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uncheck capability set' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'ConfirmationModal.suppressLabel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'stripes-core.button.continue' }));
+
+    expect(defaultProps.onChangeCapabilitySetCheckbox).toHaveBeenCalledWith(false, 'cap-set-1');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    defaultProps.onChangeCapabilitySetCheckbox.mockClear();
+
+    // Performing the same action again should confirm automatically, without showing the modal.
+    await userEvent.click(screen.getByRole('button', { name: 'uncheck capability set' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(defaultProps.onChangeCapabilitySetCheckbox).toHaveBeenCalledWith(false, 'cap-set-1');
   });
 
   it('checks capability set headers immediately without confirmation', async () => {
@@ -300,10 +322,8 @@ describe('RoleForm', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'uncheck capability sets header' }));
 
-    const modalProps = getConfirmationModalProps('unselect-capability-set-confirmation-modal');
-
-    expect(modalProps.open).toBe(true);
-    expect(modalProps.message.props.values).toEqual({
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(getFormattedMessageProps('stripes-authorization-components.capabilitySets.unselect.warning').values).toEqual({
       capabilitySet: 'Invoices - view, Loans - manage',
       capabilitiesCount: 2,
     });


### PR DESCRIPTION
## [UISAUTHCOM-98](https://folio-org.atlassian.net/browse/UISAUTHCOM-98)

Converts Confirmation Modals on the RoleForm to use `<SessionConfirmationModal>` which allows them to be suppressed by the user by checking a checkbox.

TODO:
- [x] test updates
- [x] log changes

### Result

https://github.com/user-attachments/assets/d9b6a971-a36d-40af-8076-8a24c8bef349

