### PR TITLE
UISAUTHCOM-96 (Sunflower BF) Some capabilities not shown when editing a role but shown in its detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authorization-components
 
+# IN-PROGRESS
+
+* [UISAUTHCOM-96](https://folio-org.atlassian.net/browse/UISAUTHCOM-96) Add missing associated applications back to Role Edit view.
+
 # [2.0.8](https://github.com/folio-org/stripes-authorization-components/tree/v2.0.8) (2026-01-05)
 [Full Changelog](https://github.com/folio-org/stripes-authorization-components/compare/v2.0.7...v2.0.8)
 
@@ -82,7 +86,7 @@
 * [UISAUTHCOM-12](https://folio-org.atlassian.net/browse/UISAUTHCOM-12) Ensure support for the passed `tenantId` value for manipulations in the context of a specific tenant.
 * [UISAUTHCOM-17](https://folio-org.atlassian.net/browse/UISAUTHCOM-17) Create reusable components for editing, saving Authorization policies for the consortium.
 * [UISAUTHCOM-15](https://folio-org.atlassian.net/browse/UISAUTHCOM-15) Check if user exists in Keycloak on assign users to role. If not show confirmation dialog to create user records in Keycloak.
-* [UISAUTHCOM-18](https://folio-org.atlassian.net/browse/UISAUTHCOM-18) Add button to unassign all assigned capabilities/sets when editing an authorization role in RoleForm. 
+* [UISAUTHCOM-18](https://folio-org.atlassian.net/browse/UISAUTHCOM-18) Add button to unassign all assigned capabilities/sets when editing an authorization role in RoleForm.
 * [UISAUTHCOM-19](https://folio-org.atlassian.net/browse/UISAUTHCOM-19) Create reusable hooks and components for duplicate authorization role.
 * [UISAUTHCOM-22](https://folio-org.atlassian.net/browse/UISAUTHCOM-22) Move "Select application" button to the top of the role form
 * [UISAUTHCOM-14](https://folio-org.atlassian.net/browse/UISAUTHCOM-14) ECS - Support sharing of authorization roles and policies.

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -40,7 +40,33 @@ export const RoleEdit = ({ path, tenantId }) => {
     initialRoleCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
     capabilitiesAppIds
-  } = useRoleCapabilities(roleId, tenantId);
+
+    // History:
+    // Previous changes applied expand=false which provided a convenient set of directly-assigned capabilities,
+    // but also removed certain applications from checkedAppsIdsMap that were only present via capability sets.
+    //
+    // Historical comment from UISAUTHCOM-83: https://folio-org.atlassian.net/browse/UISAUTHCOM-83
+    // expand=false so the API returns only directly-assigned capabilities (not those inherited from
+    // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
+    // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
+    // capabilities manually selected in the current editing session. When a capability set is
+    // unchecked, only the initially-loaded capabilities are removed, preserving session selections.
+    //
+    // Changes applied with UISAUTHCOM-96: https://folio-org.atlassian.net/browse/UISAUTHCOM-96
+    // expand=true pulls in capabilities that are present via capability set in addition to directly-assigned
+    // capabilities.
+    // This is needed so that owning applications of set-owned capabilities that appeared on the Role Detail page
+    // will not be excluded from this view. The data flows as follows:
+    // This 'expanded' response -> `capabilitiesAppIds` -> `checkedAppIdsMap` -> useApplicationCapabilities
+    // ultimately populate this view's capabilities table and check application checkboxes.
+    //
+    // The selectedCapabilitiesMap is now obtained by filtering out the set-owned capabilities
+    // from the now-expanded initialRoleCapabilitiesSelectedMap — see the isInitialDataReady
+    // effect below (directlyAssignedCapabilities), which is used to initialize the
+    // selectedCapabilitiesMap state.
+    // Check/uncheck behavior of Capability Sets is maintained in the current editing session, but currently does not persist - this was the acceptable
+    // trade-off for the related applications display.
+  } = useRoleCapabilities(roleId, tenantId, true);
 
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
@@ -50,7 +76,7 @@ export const RoleEdit = ({ path, tenantId }) => {
     capabilitySetsCapabilities,
     isSuccess: isInitialRoleCapabilitySetsLoaded,
     capabilitySetsAppIds,
-  } = useRoleCapabilitySets(roleId, tenantId);
+  } = useRoleCapabilitySets(roleId, tenantId, true);
 
   const {
     capabilities,
@@ -61,9 +87,11 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities({ checkedAppIdsMap,
+  } = useApplicationCapabilities({
+    checkedAppIdsMap,
     options: { tenantId },
-    setDisabledCapabilities });
+    setDisabledCapabilities
+  });
 
   const {
     capabilitySets,
@@ -75,8 +103,10 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
     actionCapabilitySets
-  } = useApplicationCapabilitySets({ checkedAppIdsMap,
-    options: { tenantId } });
+  } = useApplicationCapabilitySets({
+    checkedAppIdsMap,
+    options: { tenantId }
+  });
 
   const unselectAllCapabilitiesAndSets = () => {
     setSelectedCapabilitiesMap({});
@@ -193,13 +223,23 @@ export const RoleEdit = ({ path, tenantId }) => {
 
   useEffect(() => {
     if (isInitialDataReady) {
+
+      // Filters out set-owned capabilities per the expand=true comment above
+      // useRoleCapabilities (UISAUTHCOM-96), so selectedCapabilitiesMap only ever holds
+      // capabilities that are directly assigned / manually chosen, matching
+      // disabledCapabilities as the single source of truth for set-owned capabilities.
+      const directlyAssignedCapabilities = Object.fromEntries(
+        Object.entries(initialRoleCapabilitiesSelectedMap)
+          .filter(([id]) => !capabilitySetsCapabilities[id])
+      );
+
       // Define the selected applications and capability sets based on role ID
       // and installed applications. We update checkedAppIdsMap,
       // which triggers useChunkedApplicationCapabilities and useChunkedApplicationCapabilitySets
       // to fetch the actual data for the tables.
 
       setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetsAppIds });
-      setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap });
+      setSelectedCapabilitiesMap(directlyAssignedCapabilities);
       setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
       setDisabledCapabilities({ ...capabilitySetsCapabilities });
     }

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -53,7 +53,8 @@ export const RoleEdit = ({ path, tenantId }) => {
   // `capabilitiesAppIds` is used later with `useApplicationCapabilities` to populate all of the rows in the
   // tables of this edit view and match what the user sees in the Role Details view.
   //
-  // A second `capabilities` request is not ideal, but necessary if a proper field ('direct: true/false') for differentiating directly-assigned capabilities
+  // A second `capabilities` request is not ideal, but necessary if a
+  // field ('direct: true/false') for differentiating directly-assigned capabilities
   // (https://folio-org.atlassian.net/browse/MODROLESKC-408) is not backported to the API.
   const {
     capabilitiesAppIds,

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -39,6 +39,7 @@ export const RoleEdit = ({ path, tenantId }) => {
   const {
     initialRoleCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
+    isFetching: isRoleCapabilitiesFetching,
     capabilitiesAppIds
 
     // History:
@@ -60,10 +61,6 @@ export const RoleEdit = ({ path, tenantId }) => {
     // This 'expanded' response -> `capabilitiesAppIds` -> `checkedAppIdsMap` -> useApplicationCapabilities
     // ultimately populate this view's capabilities table and check application checkboxes.
     //
-    // The selectedCapabilitiesMap is now obtained by filtering out the set-owned capabilities
-    // from the now-expanded initialRoleCapabilitiesSelectedMap — see the isInitialDataReady
-    // effect below (directlyAssignedCapabilities), which is used to initialize the
-    // selectedCapabilitiesMap state.
     // Check/uncheck behavior of Capability Sets is maintained in the current editing session, but currently does not persist - this was the acceptable
     // trade-off for the related applications display.
   } = useRoleCapabilities(roleId, tenantId, true);
@@ -75,6 +72,7 @@ export const RoleEdit = ({ path, tenantId }) => {
     initialRoleCapabilitySetsSelectedMap,
     capabilitySetsCapabilities,
     isSuccess: isInitialRoleCapabilitySetsLoaded,
+    isFetching: isRoleCapabilitySetsFetching,
     capabilitySetsAppIds,
   } = useRoleCapabilitySets(roleId, tenantId, true);
 
@@ -218,28 +216,20 @@ export const RoleEdit = ({ path, tenantId }) => {
     }
   };
 
-  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
+  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded
+    && isInitialRoleCapabilitiesLoaded
+    && !isRoleCapabilitiesFetching
+    && !isRoleCapabilitySetsFetching;
   const isLoading = isRoleMutating || isRoleSharing;
 
   useEffect(() => {
     if (isInitialDataReady) {
-
-      // Filters out set-owned capabilities per the expand=true comment above
-      // useRoleCapabilities (UISAUTHCOM-96), so selectedCapabilitiesMap only ever holds
-      // capabilities that are directly assigned / manually chosen, matching
-      // disabledCapabilities as the single source of truth for set-owned capabilities.
-      const directlyAssignedCapabilities = Object.fromEntries(
-        Object.entries(initialRoleCapabilitiesSelectedMap)
-          .filter(([id]) => !capabilitySetsCapabilities[id])
-      );
-
       // Define the selected applications and capability sets based on role ID
       // and installed applications. We update checkedAppIdsMap,
       // which triggers useChunkedApplicationCapabilities and useChunkedApplicationCapabilitySets
       // to fetch the actual data for the tables.
-
       setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetsAppIds });
-      setSelectedCapabilitiesMap(directlyAssignedCapabilities);
+      setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap });
       setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
       setDisabledCapabilities({ ...capabilitySetsCapabilities });
     }

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -36,33 +36,28 @@ export const RoleEdit = ({ path, tenantId }) => {
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
 
+  // UISAUTHCOM-83: https://folio-org.atlassian.net/browse/UISAUTHCOM-83
+  // expand=false so the API returns only directly-assigned capabilities (not those inherited from
+  // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
+  // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
+  // capabilities manually selected.
+  // When a capability set is unchecked, only the initially-loaded capabilities are removed, preserving session selections.
   const {
     initialRoleCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
     isFetching: isRoleCapabilitiesFetching,
-    capabilitiesAppIds
+  } = useRoleCapabilities(roleId, tenantId, false);
 
-    // History:
-    // Previous changes applied expand=false which provided a convenient set of directly-assigned capabilities,
-    // but also removed certain applications from checkedAppsIdsMap that were only present via capability sets.
-    //
-    // Historical comment from UISAUTHCOM-83: https://folio-org.atlassian.net/browse/UISAUTHCOM-83
-    // expand=false so the API returns only directly-assigned capabilities (not those inherited from
-    // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
-    // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
-    // capabilities manually selected in the current editing session. When a capability set is
-    // unchecked, only the initially-loaded capabilities are removed, preserving session selections.
-    //
-    // Changes applied with UISAUTHCOM-96: https://folio-org.atlassian.net/browse/UISAUTHCOM-96
-    // expand=true pulls in capabilities that are present via capability set in addition to directly-assigned
-    // capabilities.
-    // This is needed so that owning applications of set-owned capabilities that appeared on the Role Detail page
-    // will not be excluded from this view. The data flows as follows:
-    // This 'expanded' response -> `capabilitiesAppIds` -> `checkedAppIdsMap` -> useApplicationCapabilities
-    // ultimately populate this view's capabilities table and check application checkboxes.
-    //
-    // Check/uncheck behavior of Capability Sets is maintained in the current editing session, but currently does not persist - this was the acceptable
-    // trade-off for the related applications display.
+  // UISAUTHCOM-96: https://folio-org.atlassian.net/browse/UISAUTHCOM-96
+  // expand=true pulls in capabilities that are present via capability set in addition to directly-assigned capabilities.
+  // `capabilitiesAppIds` is used later with `useApplicationCapabilities` to populate all of the rows in the
+  // tables of this edit view and match what the user sees in the Role Details view.
+  //
+  // A second `capabilities` request is not ideal, but necessary if a proper field ('direct: true/false') for differentiating directly-assigned capabilities
+  // (https://folio-org.atlassian.net/browse/MODROLESKC-408) is not backported to the API.
+  const {
+    capabilitiesAppIds,
+    isFetching: isExpandedRoleCapabilitiesFetching,
   } = useRoleCapabilities(roleId, tenantId, true);
 
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
@@ -218,6 +213,7 @@ export const RoleEdit = ({ path, tenantId }) => {
 
   const isInitialDataReady = isInitialRoleCapabilitySetsLoaded
     && isInitialRoleCapabilitiesLoaded
+    && !isExpandedRoleCapabilitiesFetching
     && !isRoleCapabilitiesFetching
     && !isRoleCapabilitySetsFetching;
   const isLoading = isRoleMutating || isRoleSharing;

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -126,6 +126,7 @@ describe('RoleEdit', () => {
     });
     useRoleCapabilitySets.mockReturnValue({
       initialRoleCapabilitySetsSelectedMap: {},
+      capabilitySetsCapabilities: {},
       isSuccess: true,
       capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true }
     });

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -159,7 +159,7 @@ describe('RoleEdit', () => {
       setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
       isLoading: false,
       queryKeys: ['core', ['app-platform-complete-0.0.5']],
-      actionCapabilities: { data:{}, settings:{}, procedural:{} }
+      actionCapabilities: { data: {}, settings: {}, procedural: {} }
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -188,7 +188,7 @@ describe('RoleEdit', () => {
         }
       ],
       queryKeys: [['app-platform-complete-0.0.5']],
-      actionCapabilitySets: { data:{}, settings:{}, procedural:{} }
+      actionCapabilitySets: { data: {}, settings: {}, procedural: {} }
     });
   });
 
@@ -324,7 +324,7 @@ describe('RoleEdit', () => {
       isLoading: false,
       actionCapabilities: {
         data: {},
-        settings:{},
+        settings: {},
         procedural: {},
       }
     });
@@ -378,7 +378,7 @@ describe('RoleEdit', () => {
       ],
       actionCapabilitySets: {
         data: {},
-        settings:{},
+        settings: {},
         procedural: {},
       }
     });
@@ -439,6 +439,108 @@ describe('RoleEdit', () => {
       expect(upsertSharedRole).toHaveBeenCalled();
       expect(mockMutateRole).not.toHaveBeenCalled();
     });
+  });
+
+  describe('stale-while-revalidate guard', () => {
+    it('should NOT initialize selected maps while capabilities are still re-fetching (isFetching: true)', () => {
+      // Simulates the re-open-after-save scenario: react-query returns stale cache immediately
+      // with isSuccess:true but marks the query as isFetching:true while the fresh request is
+      // in-flight. Without the fix the init effect would fire with stale data, causing the
+      // newly-saved capability to appear unchecked until a full page reload.
+      useRoleCapabilities.mockReturnValue({
+        initialRoleCapabilitiesSelectedMap: { 'cap-stale': true },
+        isSuccess: true,
+        isFetching: true, // background refetch still in progress
+        capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
+      });
+
+      renderComponent();
+
+      // isInitialDataReady must be false → init useEffect must not fire
+      expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalled();
+      expect(mockSetSelectedCapabilitySetsMap).not.toHaveBeenCalled();
+    });
+
+    it('should NOT initialize selected maps while capability sets are still re-fetching (isFetching: true)', () => {
+      useRoleCapabilitySets.mockReturnValue({
+        initialRoleCapabilitySetsSelectedMap: { 'set-stale': true },
+        capabilitySetsCapabilities: {},
+        isSuccess: true,
+        isFetching: true, // background refetch still in progress
+        capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true },
+      });
+
+      renderComponent();
+
+      expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalled();
+      expect(mockSetSelectedCapabilitySetsMap).not.toHaveBeenCalled();
+    });
+
+    it('should initialize selected maps once both hooks finish fetching (isFetching: false)', () => {
+      const FRESH_CAP = 'cap-fresh-after-save';
+
+      useRoleCapabilities.mockReturnValue({
+        initialRoleCapabilitiesSelectedMap: { [FRESH_CAP]: true },
+        isSuccess: true,
+        isFetching: false, // refetch complete – fresh data available
+        capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
+      });
+      useRoleCapabilitySets.mockReturnValue({
+        initialRoleCapabilitySetsSelectedMap: {},
+        capabilitySetsCapabilities: {},
+        isSuccess: true,
+        isFetching: false,
+        capabilitySetsAppIds: {},
+      });
+
+      renderComponent();
+
+      expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ [FRESH_CAP]: true });
+    });
+  });
+
+  it('should call useRoleCapabilities with expand=true so set-owned capabilities/applications are loaded', () => {
+    renderComponent();
+
+    // tenantId is undefined because no tenantId prop is passed in this test
+    expect(useRoleCapabilities).toHaveBeenCalledWith(
+      expect.anything(), // roleId
+      undefined,         // tenantId
+      true,              // expand=true: also returns capabilities inherited from capability sets (UISAUTHCOM-96)
+    );
+  });
+
+  it('should exclude set-owned capabilities from selectedCapabilitiesMap even though expand=true loads them', () => {
+    const CAP_DIRECT = '6e59c367-888a-4561-a3f3-3ca677de437f'; // directly assigned to role
+    const CAP_FROM_SET = 'cap-inherited-from-set-111';           // only comes from a capability set
+
+    // useRoleCapabilities is mocked directly here, so the real expand value doesn't drive this
+    // test. What's under test is the isInitialDataReady effect's capabilitySetsCapabilities
+    // filter: CAP_FROM_SET must be excluded from selectedCapabilitiesMap even when it's present
+    // in initialRoleCapabilitiesSelectedMap (as it would be under expand=true).
+    useRoleCapabilities.mockReturnValue({
+      initialRoleCapabilitiesSelectedMap: { [CAP_DIRECT]: true },
+      isSuccess: true,
+      capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
+    });
+
+    // The role also has a capability set whose capabilities include CAP_DIRECT and CAP_FROM_SET
+    useRoleCapabilitySets.mockReturnValue({
+      initialRoleCapabilitySetsSelectedMap: { 'd2e91897-c10d-46f6-92df-dad77c1e8862': true },
+      // capabilitySetsCapabilities tracks set-owned caps for disabledCapabilities, not selectedCapabilitiesMap
+      capabilitySetsCapabilities: { [CAP_DIRECT]: true, [CAP_FROM_SET]: true },
+      isSuccess: true,
+      capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true },
+    });
+
+    renderComponent();
+
+    // selectedCapabilitiesMap must only contain caps returned by expand=false (directly assigned)
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ [CAP_DIRECT]: true });
+    // CAP_FROM_SET must NOT be in selectedCapabilitiesMap — it is tracked only in disabledCapabilities
+    expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalledWith(
+      expect.objectContaining({ [CAP_FROM_SET]: true }),
+    );
   });
 
   it('has no a11y violations according to axe', async () => {

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -116,10 +116,18 @@ describe('RoleEdit', () => {
     mockMutateRole.mockClear();
     upsertSharedRole.mockClear();
     useEditRoleMutation.mockReturnValue({ mutateRole: mockMutateRole, isLoading: false });
-    useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true },
-      isSuccess: true
-    });
+    useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+      expand
+        ? {
+          capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
+          isFetching: false,
+        }
+        : {
+          initialRoleCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true },
+          isSuccess: true,
+          isFetching: false,
+        }
+    ));
     useRoleById.mockReturnValue({
       roleDetails: { id: '1', name: 'Admin', description: 'Description' },
       isSuccess: true
@@ -393,10 +401,11 @@ describe('RoleEdit', () => {
   });
 
   it('should call on submit select application on mocked Pluggable component ', async () => {
-    useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: {},
-      isSuccess: true
-    });
+    useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+      expand
+        ? { capabilitiesAppIds: {}, isFetching: false }
+        : { initialRoleCapabilitiesSelectedMap: {}, isSuccess: true, isFetching: false }
+    ));
     useRoleCapabilitySets.mockReturnValue({
       initialRoleCapabilitySetsSelectedMap: {},
       isSuccess: true,
@@ -442,22 +451,96 @@ describe('RoleEdit', () => {
     });
   });
 
+  it('should exclude set-owned capabilities from selectedCapabilitiesMap even though expand=true loads them', () => {
+    const CAP_DIRECT = '6e59c367-888a-4561-a3f3-3ca677de437f'; // directly assigned to role
+    const CAP_FROM_SET = 'cap-inherited-from-set-111';           // only comes from a capability set
+
+    // What's under test is the isInitialDataReady effect's capabilitySetsCapabilities filter:
+    // CAP_FROM_SET must be excluded from selectedCapabilitiesMap even though it's present in
+    // capabilitySetsCapabilities (as it would be, coming from the expand=true call below).
+    // The expand=false call only ever returns directly-assigned capabilities, so CAP_FROM_SET
+    // never appears in initialRoleCapabilitiesSelectedMap in the first place.
+    useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+      expand
+        ? { capabilitiesAppIds: { 'app-platform-complete-0.0.5': true }, isFetching: false }
+        : {
+          initialRoleCapabilitiesSelectedMap: { [CAP_DIRECT]: true },
+          isSuccess: true,
+          isFetching: false,
+        }
+    ));
+
+    // The role also has a capability set whose capabilities include CAP_DIRECT and CAP_FROM_SET
+    useRoleCapabilitySets.mockReturnValue({
+      initialRoleCapabilitySetsSelectedMap: { 'd2e91897-c10d-46f6-92df-dad77c1e8862': true },
+      // capabilitySetsCapabilities tracks set-owned caps for disabledCapabilities, not selectedCapabilitiesMap
+      capabilitySetsCapabilities: { [CAP_DIRECT]: true, [CAP_FROM_SET]: true },
+      isSuccess: true,
+      capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true },
+    });
+
+    renderComponent();
+
+    // selectedCapabilitiesMap must only contain caps returned by expand=false (directly assigned)
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ [CAP_DIRECT]: true });
+    // CAP_FROM_SET must NOT be in selectedCapabilitiesMap — it is tracked only in disabledCapabilities
+    expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalledWith(
+      expect.objectContaining({ [CAP_FROM_SET]: true }),
+    );
+  });
+
+  it('should call useRoleCapabilities twice, once with expand=false and once with expand=true', () => {
+    renderComponent();
+
+    // tenantId is undefined because no tenantId prop is passed in this test
+    expect(useRoleCapabilities).toHaveBeenCalledWith(
+      expect.anything(), // roleId
+      undefined,         // tenantId
+      false,             // expand=false: directly-assigned capabilities, used for selectedCapabilitiesMap
+    );
+    expect(useRoleCapabilities).toHaveBeenCalledWith(
+      expect.anything(), // roleId
+      undefined,         // tenantId
+      true,              // expand=true: also returns capabilities inherited from capability sets (UISAUTHCOM-96)
+    );
+  });
+
   describe('stale-while-revalidate guard', () => {
-    it('should NOT initialize selected maps while capabilities are still re-fetching (isFetching: true)', () => {
+    it('should NOT initialize selected maps while the expand=false call is still re-fetching (isFetching: true)', () => {
       // Simulates the re-open-after-save scenario: react-query returns stale cache immediately
       // with isSuccess:true but marks the query as isFetching:true while the fresh request is
       // in-flight. Without the fix the init effect would fire with stale data, causing the
       // newly-saved capability to appear unchecked until a full page reload.
-      useRoleCapabilities.mockReturnValue({
-        initialRoleCapabilitiesSelectedMap: { 'cap-stale': true },
-        isSuccess: true,
-        isFetching: true, // background refetch still in progress
-        capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
-      });
+      useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+        expand
+          ? { capabilitiesAppIds: { 'app-platform-complete-0.0.5': true }, isFetching: false }
+          : {
+            initialRoleCapabilitiesSelectedMap: { 'cap-stale': true },
+            isSuccess: true,
+            isFetching: true, // background refetch still in progress
+          }
+      ));
 
       renderComponent();
 
       // isInitialDataReady must be false → init useEffect must not fire
+      expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalled();
+      expect(mockSetSelectedCapabilitySetsMap).not.toHaveBeenCalled();
+    });
+
+    it('should NOT initialize selected maps while the expand=true call is still re-fetching (isFetching: true)', () => {
+      useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+        expand
+          ? { capabilitiesAppIds: { 'app-platform-complete-0.0.5': true }, isFetching: true } // background refetch still in progress
+          : {
+            initialRoleCapabilitiesSelectedMap: { 'cap-stale': true },
+            isSuccess: true,
+            isFetching: false,
+          }
+      ));
+
+      renderComponent();
+
       expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalled();
       expect(mockSetSelectedCapabilitySetsMap).not.toHaveBeenCalled();
     });
@@ -477,15 +560,18 @@ describe('RoleEdit', () => {
       expect(mockSetSelectedCapabilitySetsMap).not.toHaveBeenCalled();
     });
 
-    it('should initialize selected maps once both hooks finish fetching (isFetching: false)', () => {
+    it('should initialize selected maps once both useRoleCapabilities calls and useRoleCapabilitySets finish fetching (isFetching: false)', () => {
       const FRESH_CAP = 'cap-fresh-after-save';
 
-      useRoleCapabilities.mockReturnValue({
-        initialRoleCapabilitiesSelectedMap: { [FRESH_CAP]: true },
-        isSuccess: true,
-        isFetching: false, // refetch complete – fresh data available
-        capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
-      });
+      useRoleCapabilities.mockImplementation((_roleId, _tenant, expand) => (
+        expand
+          ? { capabilitiesAppIds: { 'app-platform-complete-0.0.5': true }, isFetching: false }
+          : {
+            initialRoleCapabilitiesSelectedMap: { [FRESH_CAP]: true },
+            isSuccess: true,
+            isFetching: false, // refetch complete – fresh data available
+          }
+      ));
       useRoleCapabilitySets.mockReturnValue({
         initialRoleCapabilitySetsSelectedMap: {},
         capabilitySetsCapabilities: {},
@@ -498,50 +584,6 @@ describe('RoleEdit', () => {
 
       expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ [FRESH_CAP]: true });
     });
-  });
-
-  it('should call useRoleCapabilities with expand=true so set-owned capabilities/applications are loaded', () => {
-    renderComponent();
-
-    // tenantId is undefined because no tenantId prop is passed in this test
-    expect(useRoleCapabilities).toHaveBeenCalledWith(
-      expect.anything(), // roleId
-      undefined,         // tenantId
-      true,              // expand=true: also returns capabilities inherited from capability sets (UISAUTHCOM-96)
-    );
-  });
-
-  it('should exclude set-owned capabilities from selectedCapabilitiesMap even though expand=true loads them', () => {
-    const CAP_DIRECT = '6e59c367-888a-4561-a3f3-3ca677de437f'; // directly assigned to role
-    const CAP_FROM_SET = 'cap-inherited-from-set-111';           // only comes from a capability set
-
-    // useRoleCapabilities is mocked directly here, so the real expand value doesn't drive this
-    // test. What's under test is the isInitialDataReady effect's capabilitySetsCapabilities
-    // filter: CAP_FROM_SET must be excluded from selectedCapabilitiesMap even when it's present
-    // in initialRoleCapabilitiesSelectedMap (as it would be under expand=true).
-    useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: { [CAP_DIRECT]: true },
-      isSuccess: true,
-      capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
-    });
-
-    // The role also has a capability set whose capabilities include CAP_DIRECT and CAP_FROM_SET
-    useRoleCapabilitySets.mockReturnValue({
-      initialRoleCapabilitySetsSelectedMap: { 'd2e91897-c10d-46f6-92df-dad77c1e8862': true },
-      // capabilitySetsCapabilities tracks set-owned caps for disabledCapabilities, not selectedCapabilitiesMap
-      capabilitySetsCapabilities: { [CAP_DIRECT]: true, [CAP_FROM_SET]: true },
-      isSuccess: true,
-      capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true },
-    });
-
-    renderComponent();
-
-    // selectedCapabilitiesMap must only contain caps returned by expand=false (directly assigned)
-    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ [CAP_DIRECT]: true });
-    // CAP_FROM_SET must NOT be in selectedCapabilitiesMap — it is tracked only in disabledCapabilities
-    expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalledWith(
-      expect.objectContaining({ [CAP_FROM_SET]: true }),
-    );
   });
 
   it('has no a11y violations according to axe', async () => {

--- a/lib/RoleDetails/RoleDetailsCapabilitiesAccordion/RoleDetailsCapabilitiesAccordion.js
+++ b/lib/RoleDetails/RoleDetailsCapabilitiesAccordion/RoleDetailsCapabilitiesAccordion.js
@@ -32,7 +32,7 @@ export const RoleDetailsCapabilitiesAccordion = ({ roleId, tenantId }) => {
         <Badge>
           {capabilitiesTotalCount}
         </Badge>
-    }
+      }
     >
       <CapabilitiesSection
         readOnly

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -35,7 +35,7 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
   const ky = useOkapiKy({ tenant });
   const [namespace] = useNamespace({ key: 'role-capabilities-list' });
 
-  const { data, isSuccess } = useQuery({
+  const { data, isSuccess, isFetching } = useQuery({
     queryKey: [namespace, roleId, expand, tenant],
     queryFn: () => ky.get(
       `${ROLES_API}/${roleId}/capabilities`,
@@ -81,6 +81,7 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
     initialRoleCapabilitiesSelectedMap,
     initialRoleCapabilitiesNames,
     isSuccess,
+    isFetching,
     capabilitiesTotalCount: data?.totalRecords || 0,
     groupedRoleCapabilitiesByType,
     capabilitiesAppIds

--- a/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
+++ b/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
@@ -33,7 +33,7 @@ export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
   const ky = useOkapiKy({ tenant });
   const [namespace] = useNamespace({ key: 'role-capability-sets' });
 
-  const { data, isSuccess, isLoading } = useQuery({
+  const { data, isSuccess, isLoading, isFetching } = useQuery({
     queryKey: [namespace, roleId, tenant],
     queryFn: () => ky.get(`${ROLES_API}/${roleId}/capability-sets?limit=${CAPABILITIES_LIMIT}`).json(),
     enabled: Boolean(enabled && !!roleId),
@@ -41,11 +41,11 @@ export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
   });
 
   const initialRoleCapabilitySetsSelectedMap = useMemo(() => {
-    return data?.capabilitySets.reduce((acc, capability) => {
+    return (data?.capabilitySets || []).reduce((acc, capability) => {
       acc[capability.id] = true;
 
       return acc;
-    }, {}) || {};
+    }, {});
   }, [data]);
 
   const groupedRoleCapabilitySetsByType = useMemo(() => {
@@ -56,7 +56,7 @@ export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
   to initialize the disabled capabilities
   */
   const capabilitySetsCapabilities = useMemo(() => {
-    return data?.capabilitySets
+    return (data?.capabilitySets || [])
       .flatMap(capSet => capSet.capabilities)
       .reduce((acc, item) => {
         acc[item] = true;
@@ -81,6 +81,7 @@ export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
     initialRoleCapabilitySetsNames,
     isSuccess,
     isLoading,
+    isFetching,
     capabilitySetsTotalCount: data?.totalRecords || 0,
     groupedRoleCapabilitySetsByType,
     capabilitySetsCapabilities,


### PR DESCRIPTION
## [UISAUTHCOM-96]( https://folio-org.atlassian.net/browse/UISAUTHCOM-96)

### Purpose

The Role Edit page is missing application entries that are present on the Role Details page.

### Approach
Added another call of `useRoleCapabilites` with `expand=true` to fill out `capabilitiesAppIds` from the associated, inherited capabilities, not exclusively the directly selected capabilities.

If https://folio-org.atlassian.net/browse/MODROLESKC-408 is backported, this will be unnecessary, since the directly assigned capabilities can be discerned from the inherited ones in a single call with `expand=true`.
    
Check/uncheck behavior of Capability Sets is maintained and persists.

Adding `isFetching` to output from hooks so that we can wait for initial data to be loaded.

The capabilities endpoint in Umbrellaleaf includes the `direct` field on capabilities, so it's much easier for the UI to distinguish directly-assigned capabilities vs inherited ones.

Tests updated to reflect the current state of the code.

### Bugfix: (Same apps showing up in tables on Edit screen as appear on the Details view.)

https://github.com/user-attachments/assets/a7d09574-4003-4065-847d-7306d37e3daa

### Capability Sets selection/deselection:

https://github.com/user-attachments/assets/b496c090-ba26-445c-9303-588e97689d18

### Re-edit

https://github.com/user-attachments/assets/71710529-7f32-4ec1-9e71-4f6c6fae0f2b


## Inherited/direct-assignment Capabilities

https://github.com/user-attachments/assets/4a3fb68e-5301-42b7-9808-0139efab1759


## Cross-session persistence

https://github.com/user-attachments/assets/cf334c2b-981a-4247-9703-c2962ddeeb58

