### PR TITLE
UISAUTHCOM-96 Role Edit missing capabilities/applications - U10f version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # IN-PROGRESS
 
 * [UISAUTHCOM-97](https://folio-org.atlassian.net/browse/UISAUTHCOM-97) Add validation to RoleForm for Role Name. Disallowed forward slash "/" and required the name field for form submission.
+* [UISAUTHCOM-96](https://folio-org.atlassian.net/browse/UISAUTHCOM-96) Some capabilities not shown when editing a role but shown in its detail view.
 
 # [2.2.0](https://github.com/folio-org/stripes-authorization-components/tree/v2.2.0)
 

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -36,16 +36,13 @@ export const RoleEdit = ({ path, tenantId }) => {
   const [description, setDescription] = useState('');
 
   const {
-    initialRoleCapabilitiesSelectedMap,
+    initialDirectCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
     isFetching: isRoleCapabilitiesFetching,
     capabilitiesAppIds
-  // expand=false so the API returns only directly-assigned capabilities (not those inherited from
-  // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
-  // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
-  // capabilities manually selected in the current editing session. When a capability set is
-  // unchecked, only the initially-loaded capabilities are removed, preserving session selections.
-  } = useRoleCapabilities(roleId, tenantId, false);
+    // using expand=true to get all inherited and direct capablityAppIds for the role
+    // so that this view can present the same applications as the Details view.
+  } = useRoleCapabilities(roleId, tenantId, true);
 
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
@@ -69,9 +66,11 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities({ checkedAppIdsMap,
+  } = useApplicationCapabilities({
+    checkedAppIdsMap,
     options: { tenantId },
-    setDisabledCapabilities });
+    setDisabledCapabilities
+  });
 
   const {
     capabilitySets,
@@ -83,8 +82,10 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
     actionCapabilitySets
-  } = useApplicationCapabilitySets({ checkedAppIdsMap,
-    options: { tenantId } });
+  } = useApplicationCapabilitySets({
+    checkedAppIdsMap,
+    options: { tenantId }
+  });
 
   const unselectAllCapabilitiesAndSets = () => {
     setSelectedCapabilitiesMap({});
@@ -113,7 +114,7 @@ export const RoleEdit = ({ path, tenantId }) => {
   };
 
   const isRoleShared = Boolean(stripes.hasInterface('consortia') && isShared(roleDetails));
-  const shouldUpdateCapabilities = !isEqual(initialRoleCapabilitiesSelectedMap, selectedCapabilitiesMap);
+  const shouldUpdateCapabilities = !isEqual(initialDirectCapabilitiesSelectedMap, selectedCapabilitiesMap);
   const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitySetsMap);
 
   const {
@@ -220,7 +221,7 @@ export const RoleEdit = ({ path, tenantId }) => {
       // to fetch the actual data for the tables.
 
       setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetsAppIds });
-      setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap });
+      setSelectedCapabilitiesMap({ ...initialDirectCapabilitiesSelectedMap });
       setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
       setDisabledCapabilities({ ...capabilitySetsCapabilities });
     }

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -117,7 +117,7 @@ describe('RoleEdit', () => {
     upsertSharedRole.mockClear();
     useEditRoleMutation.mockReturnValue({ mutateRole: mockMutateRole, isLoading: false });
     useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true },
+      initialDirectCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true },
       isSuccess: true
     });
     useRoleById.mockReturnValue({
@@ -422,7 +422,7 @@ describe('RoleEdit', () => {
 
   it('should call on submit select application on mocked Pluggable component ', async () => {
     useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: {},
+      initialDirectCapabilitiesSelectedMap: {},
       isSuccess: true
     });
     useRoleCapabilitySets.mockReturnValue({
@@ -477,7 +477,7 @@ describe('RoleEdit', () => {
       // in-flight. Without the fix the init effect would fire with stale data, causing the
       // newly-saved capability to appear unchecked until a full page reload.
       useRoleCapabilities.mockReturnValue({
-        initialRoleCapabilitiesSelectedMap: { 'cap-stale': true },
+        initialDirectCapabilitiesSelectedMap: { 'cap-stale': true },
         isSuccess: true,
         isFetching: true, // background refetch still in progress
         capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
@@ -509,7 +509,7 @@ describe('RoleEdit', () => {
       const FRESH_CAP = 'cap-fresh-after-save';
 
       useRoleCapabilities.mockReturnValue({
-        initialRoleCapabilitiesSelectedMap: { [FRESH_CAP]: true },
+        initialDirectCapabilitiesSelectedMap: { [FRESH_CAP]: true },
         isSuccess: true,
         isFetching: false, // refetch complete – fresh data available
         capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
@@ -528,25 +528,25 @@ describe('RoleEdit', () => {
     });
   });
 
-  it('should call useRoleCapabilities with expand=false to exclude set-inherited capabilities from initial state', () => {
+  it('should call useRoleCapabilities with expand=true to get all inherited and direct capabilityAppIds', () => {
     renderComponent();
 
     // tenantId is undefined because no tenantId prop is passed in this test
     expect(useRoleCapabilities).toHaveBeenCalledWith(
       expect.anything(), // roleId
       undefined,         // tenantId
-      false,             // expand=false: only directly-assigned capabilities, not those inherited from sets
+      true,              // expand=true: includes both directly-assigned and set-inherited capabilities
     );
   });
 
-  it('should initialize selectedCapabilitiesMap from expand=false result, excluding set-inherited capabilities', () => {
+  it('should initialize selectedCapabilitiesMap from initialDirectCapabilitiesSelectedMap, excluding set-inherited capabilities', () => {
     const CAP_DIRECT = '6e59c367-888a-4561-a3f3-3ca677de437f'; // directly assigned to role
     const CAP_FROM_SET = 'cap-inherited-from-set-111';           // only comes from a capability set
 
-    // expand=false returns only the directly-assigned cap, NOT the set-inherited one.
-    // With expand=true the API would have returned both caps, causing the set-uncheck bug.
+    // initialDirectCapabilitiesSelectedMap only contains capabilities with `direct: true`, even
+    // though expand=true causes the API to also return set-inherited capabilities.
     useRoleCapabilities.mockReturnValue({
-      initialRoleCapabilitiesSelectedMap: { [CAP_DIRECT]: true },
+      initialDirectCapabilitiesSelectedMap: { [CAP_DIRECT]: true },
       isSuccess: true,
       capabilitiesAppIds: { 'app-platform-complete-0.0.5': true },
     });

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -89,20 +89,10 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
     }, []) || [];
   }, [data]);
 
-  const initialDirectCapabilitiesNames = useMemo(() => {
-    return data?.capabilities?.reduce((acc, capability) => {
-      if (capability.direct) {
-        acc.push(capability.name);
-      }
-      return acc;
-    }, []) || [];
-  }, [data]);
-
   return {
     initialRoleCapabilitiesSelectedMap,
     initialDirectCapabilitiesSelectedMap,
     initialRoleCapabilitiesNames,
-    initialDirectCapabilitiesNames,
     isSuccess,
     isFetching,
     capabilitiesTotalCount: data?.totalRecords || 0,

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -55,7 +55,16 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
     if (!data) return {};
     return data?.capabilities.reduce((acc, capability) => {
       acc[capability.id] = true;
+      return acc;
+    }, {}) || {};
+  }, [data]);
 
+  const initialDirectCapabilitiesSelectedMap = useMemo(() => {
+    if (!data) return {};
+    return data?.capabilities.reduce((acc, capability) => {
+      if (capability.direct) {
+        acc[capability.id] = true;
+      }
       return acc;
     }, {}) || {};
   }, [data]);
@@ -74,12 +83,26 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
   }, [data]);
 
   const initialRoleCapabilitiesNames = useMemo(() => {
-    return data?.capabilities?.map(({ name }) => name);
+    return data?.capabilities?.reduce((acc, capability) => {
+      acc.push(capability.name);
+      return acc;
+    }, []) || [];
+  }, [data]);
+
+  const initialDirectCapabilitiesNames = useMemo(() => {
+    return data?.capabilities?.reduce((acc, capability) => {
+      if (capability.direct) {
+        acc.push(capability.name);
+      }
+      return acc;
+    }, []) || [];
   }, [data]);
 
   return {
     initialRoleCapabilitiesSelectedMap,
+    initialDirectCapabilitiesSelectedMap,
     initialRoleCapabilitiesNames,
+    initialDirectCapabilitiesNames,
     isSuccess,
     isFetching,
     capabilitiesTotalCount: data?.totalRecords || 0,

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.test.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.test.js
@@ -43,6 +43,7 @@ const data = {
         'role-capabilities.collection.get',
       ],
       type: 'data',
+      direct: true,
       metadata: {
         createdDate: '2023-07-14T15:32:15.56000:00',
         modifiedDate: '2023-07-14T15:32:15.561+00:00',
@@ -61,6 +62,7 @@ const data = {
         'role-capabilities.collection.get',
       ],
       type: 'settings',
+      direct: false,
       metadata: {
         createdDate: '2023-07-14T15:32:15.560+00:00',
         modifiedDate: '2023-07-14T15:32:15.561+00:00',
@@ -91,6 +93,10 @@ const expectedInitialRoleCapabilitiesSelectedMap = {
   'data-capability-id': true,
   'settings-capability-id': true,
   'procedural-capability-id': true,
+};
+
+const expectedInitialDirectCapabilitiesSelectedMap = {
+  'data-capability-id': true,
 };
 
 const expectedGroupedRoleCapabilitiesByType = {
@@ -157,8 +163,24 @@ describe('useRoleCapabilities', () => {
 
     expect(result.current.isSuccess).toBe(true);
     expect(result.current.initialRoleCapabilitiesSelectedMap).toEqual(expectedInitialRoleCapabilitiesSelectedMap);
+    expect(result.current.initialDirectCapabilitiesSelectedMap).toEqual(expectedInitialDirectCapabilitiesSelectedMap);
     expect(result.current.capabilitiesTotalCount).toEqual(2);
     expect(result.current.groupedRoleCapabilitiesByType).toEqual(expectedGroupedRoleCapabilitiesByType);
     expect(result.current.capabilitiesAppIds).toEqual({ 'app-platform-minimal-0.0.4': true });
+  });
+
+  it('returns an empty initialDirectCapabilitiesSelectedMap when no capabilities are direct', async () => {
+    mockGet.mockReturnValueOnce({
+      json: () => Promise.resolve({
+        ...data,
+        capabilities: data.capabilities.map((capability) => ({ ...capability, direct: false })),
+      }),
+    });
+
+    const { result } = renderHook(() => useRoleCapabilities(1), { wrapper });
+
+    await act(() => result.current.isSuccess);
+
+    expect(result.current.initialDirectCapabilitiesSelectedMap).toEqual({});
   });
 });


### PR DESCRIPTION
## [UISAUTHCOM-96](https://folio-org.atlassian.net/browse/UISAUTHCOM-96) RoleEdit is missing capabilities in comparison to RoleDetails.

#153 except only a single request is necessary since https://folio-org.atlassian.net/browse/MODROLESKC-408 is deployed on snapshot.

### Approach
I added "Direct" version of output key for `useRoleCapabilites` hook: `initialDirectCapabilitiesSelectedMap`. I used this in the role form. Existing output keys were left untouched for other views that use them.

### UPDATE:
Talks about backporting the necessary backend feature for this to be backported are going to happen. The approach here is preferable to #153 -- 🤞 Given the nature of these hooks, this implementation will change/be absorbed by other updates like #155 (usage-provided set of `filter` predicates.)


### Tidy up that initial state of direct capabilities with `expand = true`  - 
<img width="863" height="456" alt="image" src="https://github.com/user-attachments/assets/90abf50c-c00c-45b1-a1b4-fdffd02ee9a5" />

### Bugfix: (Same capabilities/apps on Edit screen as appear on the Details)
https://github.com/user-attachments/assets/fa5bcef2-93a5-4caa-8cb7-19420c75521a

### Direct/Inherited Checkbox behavior

https://github.com/user-attachments/assets/ae3033bd-0414-43b7-9cad-91c7343d84c4

### Cross-session persistence

https://github.com/user-attachments/assets/369d9bf9-5819-44d9-a6fc-77b66a15d387



