### PR TITLE
UISAUTHCOM-101 Filter capabilities based on 'visibility' attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # IN-PROGRESS
 
 * [UISAUTHCOM-97](https://folio-org.atlassian.net/browse/UISAUTHCOM-97) Add validation to RoleForm for Role Name. Disallowed forward slash "/" and required the name field for form submission.
+* [UISAUTHCOM-101](https://folio-org.atlassian.net/browse/UISAUTHCOM-101) Show/hid capabilities based on the "visible" attribute.
 
 # [2.2.0](https://github.com/folio-org/stripes-authorization-components/tree/v2.2.0)
 

--- a/lib/Role/RoleCreate/RoleCreate.js
+++ b/lib/Role/RoleCreate/RoleCreate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useHistory } from 'react-router';
 import { isEmpty } from 'lodash';
 
@@ -12,6 +12,7 @@ import {
   useRoleMutationErrorHandler,
   useShowCallout,
 } from '../../hooks';
+import { composeFilters, isCapabilityVisible } from '../../utils';
 import { RoleForm } from '../RoleForm';
 import { getCheckboxHandlers, changesForUnselect } from '../utils';
 
@@ -28,6 +29,18 @@ export const RoleCreate = ({
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
   const [isUnselectApplicationConfirmationOpen, setIsUnselectApplicationConfirmationOpen] = useState(false);
   const [unselectedItemsInfo, setUnselectedItemsInfo] = useState({});
+  const [showHidden, setShowHidden] = useState(false);
+
+  const visibilityFilter = useMemo(
+    () => (capability) => showHidden || isCapabilityVisible(capability),
+    [showHidden],
+  );
+  // Future filters (search text, type, action, ...) are added here as their own
+  // memoized predicate and appended to composeFilters below.
+  const capabilitiesFilter = useMemo(
+    () => composeFilters(visibilityFilter),
+    [visibilityFilter],
+  );
 
   const {
     capabilities,
@@ -37,9 +50,12 @@ export const RoleCreate = ({
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities({ checkedAppIdsMap,
-    options:{ tenantId },
-    setDisabledCapabilities });
+  } = useApplicationCapabilities({
+    checkedAppIdsMap,
+    options: { tenantId },
+    setDisabledCapabilities,
+    filter: capabilitiesFilter
+  });
 
   const {
     capabilitySets,
@@ -50,7 +66,11 @@ export const RoleCreate = ({
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
     actionCapabilitySets
-  } = useApplicationCapabilitySets({ checkedAppIdsMap, options: { tenantId } });
+  } = useApplicationCapabilitySets({
+    checkedAppIdsMap,
+    options: { tenantId },
+    filter: capabilitiesFilter
+  });
 
   const { handleError } = useRoleMutationErrorHandler();
 
@@ -153,6 +173,8 @@ export const RoleCreate = ({
       isCapabilitySelected={isCapabilitySelected}
       setRoleName={setRoleName}
       setDescription={setDescription}
+      setShowHidden={setShowHidden}
+      showHidden={showHidden}
       onSubmit={onSubmit}
       onClose={onClose}
       onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}

--- a/lib/Role/RoleCreate/RoleCreate.test.js
+++ b/lib/Role/RoleCreate/RoleCreate.test.js
@@ -78,8 +78,8 @@ describe('RoleCreate', () => {
       isLoading: false,
       queryKeys: ['capabilities', ['app-platform-complete-0.0.5']],
       actionCapabilities: {
-        data:{},
-        settings:{},
+        data: {},
+        settings: {},
         procedural: {},
       }
     });
@@ -110,8 +110,8 @@ describe('RoleCreate', () => {
       isLoading: false,
       queryKeys: ['capabilitySets', ['app-platform-complete-0.0.5']],
       actionCapabilitySets: {
-        data:{},
-        settings:{},
+        data: {},
+        settings: {},
         procedural: {},
       }
     });
@@ -169,7 +169,7 @@ describe('RoleCreate', () => {
       expect(mockMutateRole).toHaveBeenCalledWith({ name: 'New Role', description: '' });
       expect(mockRemoveQueries).toHaveBeenCalledTimes(2);
       expect(mockRemoveQueries).toHaveBeenNthCalledWith(1, { queryKey: ['capabilities', 'app-platform-complete-0.0.5'] });
-      expect(mockRemoveQueries).toHaveBeenNthCalledWith(2, { queryKey:['capabilitySets', 'app-platform-complete-0.0.5'] });
+      expect(mockRemoveQueries).toHaveBeenNthCalledWith(2, { queryKey: ['capabilitySets', 'app-platform-complete-0.0.5'] });
     });
 
     it('cancel button', async () => {
@@ -190,7 +190,7 @@ describe('RoleCreate', () => {
     const { getAllByRole } = renderComponent();
 
     await waitFor(async () => {
-      await userEvent.click(getAllByRole('checkbox')[6]);
+      await userEvent.click(getAllByRole('checkbox')[7]);
     });
 
     expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledTimes(1);
@@ -217,6 +217,97 @@ describe('RoleCreate', () => {
       await userEvent.click(getByRole('button', { name: 'stripes-components.saveAndClose' }));
 
       expect(sendCallout).toHaveBeenCalled();
+    });
+  });
+
+  describe('show hidden capabilities filter', () => {
+    const visibleCapability = {
+      id: 'cap-visible',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Visible Capability',
+      actions: { view: 'cap-visible' },
+      visible: true,
+    };
+    const hiddenCapability = {
+      id: 'cap-hidden',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Hidden Capability',
+      actions: { view: 'cap-hidden' },
+      visible: false,
+    };
+    const visibleCapabilitySet = {
+      id: 'cap-set-visible',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Visible Capability Set',
+      action: 'view',
+      type: 'data',
+      actions: { view: 'cap-set-visible' },
+      capabilities: [],
+      visible: true,
+    };
+    const hiddenCapabilitySet = {
+      id: 'cap-set-hidden',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Hidden Capability Set',
+      action: 'view',
+      type: 'data',
+      actions: { view: 'cap-set-hidden' },
+      capabilities: [],
+      visible: false,
+    };
+
+    beforeEach(() => {
+      useApplicationCapabilities.mockImplementation(({ filter }) => ({
+        capabilities: {
+          data: [visibleCapability, hiddenCapability].filter(filter),
+          procedural: [],
+          settings: [],
+        },
+        roleCapabilitiesListIds: [],
+        selectedCapabilitiesMap: {},
+        setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
+        isLoading: false,
+        queryKeys: ['capabilities', []],
+        actionCapabilities: { data: {}, settings: {}, procedural: {} },
+      }));
+
+      useApplicationCapabilitySets.mockImplementation(({ filter }) => {
+        const capabilitySetsList = [visibleCapabilitySet, hiddenCapabilitySet].filter(filter);
+
+        return {
+          capabilitySets: { data: capabilitySetsList, procedural: [], settings: [] },
+          capabilitySetsList,
+          roleCapabilitySetsListIds: [],
+          selectedCapabilitySetsMap: {},
+          setSelectedCapabilitySetsMap: jest.fn(),
+          isLoading: false,
+          queryKeys: ['capabilitySets', []],
+          actionCapabilitySets: { data: {}, settings: {}, procedural: {} },
+        };
+      });
+    });
+
+    it('hides non-visible capabilities and capability sets until "show hidden" is checked', async () => {
+      const { getByRole, getByText, queryByText } = renderComponent();
+
+      expect(getByText('Visible Capability')).toBeInTheDocument();
+      expect(queryByText('Hidden Capability')).not.toBeInTheDocument();
+      expect(getByText('Visible Capability Set')).toBeInTheDocument();
+      expect(queryByText('Hidden Capability Set')).not.toBeInTheDocument();
+
+      const showHiddenCheckbox = getByRole('checkbox', {
+        name: 'stripes-authorization-components.form.labels.showHidden',
+      });
+
+      expect(showHiddenCheckbox).not.toBeChecked();
+
+      await act(async () => {
+        await userEvent.click(showHiddenCheckbox);
+      });
+
+      expect(showHiddenCheckbox).toBeChecked();
+      expect(getByText('Hidden Capability')).toBeInTheDocument();
+      expect(getByText('Hidden Capability Set')).toBeInTheDocument();
     });
   });
 

--- a/lib/Role/RoleEdit/RoleEdit.js
+++ b/lib/Role/RoleEdit/RoleEdit.js
@@ -1,6 +1,6 @@
 import { isEmpty, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useQueryClient } from 'react-query';
 import { useParams, useHistory } from 'react-router-dom';
 
@@ -18,7 +18,7 @@ import {
   useRoleSharing,
   useShowCallout,
 } from '../../hooks';
-import { isShared } from '../../utils';
+import { composeFilters, isCapabilityVisible, isShared } from '../../utils';
 import { RoleForm } from '../RoleForm';
 import { getCheckboxHandlers, changesForUnselect } from '../utils';
 
@@ -34,18 +34,36 @@ export const RoleEdit = ({ path, tenantId }) => {
 
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
+  const [showHidden, setShowHidden] = useState(false);
+
+  const visibilityFilter = useMemo(
+    () => (capability) => showHidden || isCapabilityVisible(capability),
+    [showHidden],
+  );
+  // Future filters (search text, type, action, ...) are added here as their own
+  // memoized predicate and appended to composeFilters below.
+  const capabilitiesFilter = useMemo(
+    () => composeFilters(visibilityFilter),
+    [visibilityFilter],
+  );
 
   const {
     initialRoleCapabilitiesSelectedMap,
     isSuccess: isInitialRoleCapabilitiesLoaded,
     isFetching: isRoleCapabilitiesFetching,
     capabilitiesAppIds
-  // expand=false so the API returns only directly-assigned capabilities (not those inherited from
-  // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
-  // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
-  // capabilities manually selected in the current editing session. When a capability set is
-  // unchecked, only the initially-loaded capabilities are removed, preserving session selections.
-  } = useRoleCapabilities(roleId, tenantId, false);
+    // expand=false so the API returns only directly-assigned capabilities (not those inherited from
+    // capability sets). This keeps selectedCapabilitiesMap clean of set-owned capabilities, which
+    // allows us to correctly distinguish between capabilities that were loaded from saved state vs.
+    // capabilities manually selected in the current editing session. When a capability set is
+    // unchecked, only the initially-loaded capabilities are removed, preserving session selections.
+  } = useRoleCapabilities(
+    roleId,
+    tenantId,
+    true,
+    {},
+    capabilitiesFilter,
+  );
 
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
@@ -58,7 +76,7 @@ export const RoleEdit = ({ path, tenantId }) => {
     isSuccess: isInitialRoleCapabilitySetsLoaded,
     isFetching: isRoleCapabilitySetsFetching,
     capabilitySetsAppIds,
-  } = useRoleCapabilitySets(roleId, tenantId, true);
+  } = useRoleCapabilitySets(roleId, tenantId, {}, capabilitiesFilter);
 
   const {
     capabilities,
@@ -69,9 +87,12 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitiesLoading,
     queryKeys: applicationCapabilitiesQueryKeys,
     actionCapabilities
-  } = useApplicationCapabilities({ checkedAppIdsMap,
+  } = useApplicationCapabilities({
+    checkedAppIdsMap,
     options: { tenantId },
-    setDisabledCapabilities });
+    setDisabledCapabilities,
+    filter: capabilitiesFilter,
+  });
 
   const {
     capabilitySets,
@@ -83,8 +104,11 @@ export const RoleEdit = ({ path, tenantId }) => {
     isLoading: isAppCapabilitySetsLoading,
     queryKeys: applicationCapabilitySetsQueryKeys,
     actionCapabilitySets
-  } = useApplicationCapabilitySets({ checkedAppIdsMap,
-    options: { tenantId } });
+  } = useApplicationCapabilitySets({
+    checkedAppIdsMap,
+    options: { tenantId },
+    filter: capabilitiesFilter,
+  });
 
   const unselectAllCapabilitiesAndSets = () => {
     setSelectedCapabilitiesMap({});
@@ -245,6 +269,8 @@ export const RoleEdit = ({ path, tenantId }) => {
       isCapabilitySetSelected={isCapabilitySetSelected}
       setRoleName={setRoleName}
       setDescription={setDescription}
+      setShowHidden={setShowHidden}
+      showHidden={showHidden}
       onSubmit={onSubmit}
       onClose={onClose}
       onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}

--- a/lib/Role/RoleEdit/RoleEdit.test.js
+++ b/lib/Role/RoleEdit/RoleEdit.test.js
@@ -159,7 +159,7 @@ describe('RoleEdit', () => {
       setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
       isLoading: false,
       queryKeys: ['core', ['app-platform-complete-0.0.5']],
-      actionCapabilities: { data:{}, settings:{}, procedural:{} }
+      actionCapabilities: { data: {}, settings: {}, procedural: {} }
     });
 
     useApplicationCapabilitySets.mockReturnValue({
@@ -188,7 +188,7 @@ describe('RoleEdit', () => {
         }
       ],
       queryKeys: [['app-platform-complete-0.0.5']],
-      actionCapabilitySets: { data:{}, settings:{}, procedural:{} }
+      actionCapabilitySets: { data: {}, settings: {}, procedural: {} }
     });
   });
 
@@ -292,8 +292,11 @@ describe('RoleEdit', () => {
     const headerCheckboxes = 4 * 3;
     const capabilitiesCheckboxLength = 2;
     const capabilitySetsCheckboxLength = 1;
+    const showHiddenCheckboxLength = 1;
 
-    expect(getAllByRole('checkbox').length).toBe(capabilitiesCheckboxLength + capabilitySetsCheckboxLength + headerCheckboxes);
+    expect(getAllByRole('checkbox').length).toBe(
+      capabilitiesCheckboxLength + capabilitySetsCheckboxLength + headerCheckboxes + showHiddenCheckboxLength
+    );
     expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledTimes(1);
     expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ '6e59c367-888a-4561-a3f3-3ca677de437f': true });
     expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(1);
@@ -353,7 +356,7 @@ describe('RoleEdit', () => {
       isLoading: false,
       actionCapabilities: {
         data: {},
-        settings:{},
+        settings: {},
         procedural: {},
       }
     });
@@ -371,8 +374,8 @@ describe('RoleEdit', () => {
     const { getAllByRole } = renderComponent();
 
     await act(async () => {
-      // first 4 checkboxes are header checkboxes
-      await userEvent.click(getAllByRole('checkbox')[5]);
+      // index 0 is the "show hidden" checkbox, followed by 4 header checkboxes
+      await userEvent.click(getAllByRole('checkbox')[6]);
     });
 
     expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(2);
@@ -407,14 +410,15 @@ describe('RoleEdit', () => {
       ],
       actionCapabilitySets: {
         data: {},
-        settings:{},
+        settings: {},
         procedural: {},
       }
     });
     const { getAllByRole } = renderComponent();
 
     await act(async () => {
-      await userEvent.click(getAllByRole('checkbox')[0]);
+      // index 0 is the "show hidden" checkbox; index 1 is the capability sets header checkbox
+      await userEvent.click(getAllByRole('checkbox')[1]);
     });
 
     expect(mockSetSelectedCapabilitySetsMap).toHaveBeenCalledTimes(2);
@@ -528,14 +532,16 @@ describe('RoleEdit', () => {
     });
   });
 
-  it('should call useRoleCapabilities with expand=false to exclude set-inherited capabilities from initial state', () => {
+  it('should call useRoleCapabilities with the expand flag and composed visibility filter currently wired in', () => {
     renderComponent();
 
     // tenantId is undefined because no tenantId prop is passed in this test
     expect(useRoleCapabilities).toHaveBeenCalledWith(
-      expect.anything(), // roleId
-      undefined,         // tenantId
-      false,             // expand=false: only directly-assigned capabilities, not those inherited from sets
+      expect.anything(),    // roleId
+      undefined,            // tenantId
+      true,                 // expand flag as currently wired
+      {},                   // options
+      expect.any(Function), // composed visibility filter
     );
   });
 
@@ -568,6 +574,97 @@ describe('RoleEdit', () => {
     expect(mockSetSelectedCapabilitiesMap).not.toHaveBeenCalledWith(
       expect.objectContaining({ [CAP_FROM_SET]: true }),
     );
+  });
+
+  describe('show hidden capabilities filter', () => {
+    const visibleCapability = {
+      id: 'cap-visible',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Visible Capability',
+      actions: { view: 'cap-visible' },
+      visible: true,
+    };
+    const hiddenCapability = {
+      id: 'cap-hidden',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Hidden Capability',
+      actions: { view: 'cap-hidden' },
+      visible: false,
+    };
+    const visibleCapabilitySet = {
+      id: 'cap-set-visible',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Visible Capability Set',
+      action: 'view',
+      type: 'data',
+      actions: { view: 'cap-set-visible' },
+      capabilities: [],
+      visible: true,
+    };
+    const hiddenCapabilitySet = {
+      id: 'cap-set-hidden',
+      applicationId: 'app-platform-complete-0.0.5',
+      resource: 'Hidden Capability Set',
+      action: 'view',
+      type: 'data',
+      actions: { view: 'cap-set-hidden' },
+      capabilities: [],
+      visible: false,
+    };
+
+    beforeEach(() => {
+      useApplicationCapabilities.mockImplementation(({ filter }) => ({
+        capabilities: {
+          data: [visibleCapability, hiddenCapability].filter(filter),
+          procedural: [],
+          settings: [],
+        },
+        roleCapabilitiesListIds: [],
+        selectedCapabilitiesMap: {},
+        setSelectedCapabilitiesMap: mockSetSelectedCapabilitiesMap,
+        isLoading: false,
+        queryKeys: ['core', []],
+        actionCapabilities: { data: {}, settings: {}, procedural: {} },
+      }));
+
+      useApplicationCapabilitySets.mockImplementation(({ filter }) => {
+        const capabilitySetsList = [visibleCapabilitySet, hiddenCapabilitySet].filter(filter);
+
+        return {
+          capabilitySets: { data: capabilitySetsList, procedural: [], settings: [] },
+          capabilitySetsList,
+          setSelectedCapabilitySetsMap: mockSetSelectedCapabilitySetsMap,
+          selectedCapabilitySetsMap: {},
+          roleCapabilitySetsListIds: [],
+          isLoading: false,
+          queryKeys: [[]],
+          actionCapabilitySets: { data: {}, settings: {}, procedural: {} },
+        };
+      });
+    });
+
+    it('hides non-visible capabilities and capability sets until "show hidden" is checked', async () => {
+      const { getByRole, getByText, queryByText } = renderComponent();
+
+      expect(getByText('Visible Capability')).toBeInTheDocument();
+      expect(queryByText('Hidden Capability')).not.toBeInTheDocument();
+      expect(getByText('Visible Capability Set')).toBeInTheDocument();
+      expect(queryByText('Hidden Capability Set')).not.toBeInTheDocument();
+
+      const showHiddenCheckbox = getByRole('checkbox', {
+        name: 'stripes-authorization-components.form.labels.showHidden',
+      });
+
+      expect(showHiddenCheckbox).not.toBeChecked();
+
+      await act(async () => {
+        await userEvent.click(showHiddenCheckbox);
+      });
+
+      expect(showHiddenCheckbox).toBeChecked();
+      expect(getByText('Hidden Capability')).toBeInTheDocument();
+      expect(getByText('Hidden Capability Set')).toBeInTheDocument();
+    });
   });
 
   it('has no a11y violations according to axe', async () => {

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -7,6 +7,7 @@ import {
   AccordionSet,
   AccordionStatus, Button,
   ConfirmationModal,
+  Checkbox,
   ExpandAllButton,
   Layer,
   Pane,
@@ -15,6 +16,8 @@ import {
   Paneset,
   TextArea,
   TextField,
+  Row,
+  Col,
 } from '@folio/stripes/components';
 
 import { Pluggable } from '@folio/stripes/core';
@@ -27,6 +30,8 @@ import { validateNoSlashCharacter, validateRoleName } from '../../utils/validati
 
 import css from '../style.css';
 
+const areCapabilitiesEmpty = (capabilities) => Object.values(capabilities).every(arr => arr.length === 0);
+
 export const RoleForm = ({
   title,
   roleName,
@@ -36,6 +41,8 @@ export const RoleForm = ({
   isLoading,
   setRoleName,
   setDescription,
+  setShowHidden,
+  showHidden,
   onSubmit,
   onClose,
   onChangeCapabilityCheckbox,
@@ -220,27 +227,41 @@ export const RoleForm = ({
                   data-testid="description-input"
                 />
               </Accordion>
-
-              <Pluggable
-                type="select-application"
-                checkedAppIdsMap={checkedAppIdsMap}
-                onSave={onSaveSelectedApplications}
-                renderTrigger={props => (
-                  <Button
-                    {...props}
-                    icon="plus-sign"
-                    disabled={isLoading}
-                  >
-                    <FormattedMessage
-                      id="stripes-authorization-components.crud.selectApplication"
-                    />
-                  </Button>
-                )}
-              >
-                <FormattedMessage
-                  id="stripes-authorization-components.applications.notAvailable"
+              <Row style={{ gap: '4px' }}>
+                <Pluggable
+                  type="select-application"
+                  checkedAppIdsMap={checkedAppIdsMap}
+                  onSave={onSaveSelectedApplications}
+                  renderTrigger={props => (
+                    <Button
+                      {...props}
+                      icon="plus-sign"
+                      disabled={isLoading}
+                    >
+                      <FormattedMessage
+                        id="stripes-authorization-components.crud.selectApplication"
+                      />
+                    </Button>
+                  )}
+                >
+                  <FormattedMessage
+                    id="stripes-authorization-components.applications.notAvailable"
+                  />
+                </Pluggable>
+                {!!unselectAllCapabilitiesAndSets && <Button
+                  disabled={isLoading}
+                  onClick={unselectAllCapabilitiesAndSets}
+                >
+                  <FormattedMessage id="stripes-authorization-components.form.unassignAllCapabilities" />
+                </Button>}
+                <Checkbox
+                  label={intl.formatMessage({ id: 'stripes-authorization-components.form.labels.showHidden' })}
+                  checked={showHidden}
+                  disabled={isLoading || areCapabilitiesEmpty(capabilities)}
+                  onChange={e => setShowHidden(e.target.checked)}
                 />
-              </Pluggable>
+              </Row>
+
               <ConfirmationModal
                 id="unselect-application-confirmation-modal"
                 open={isUnselectApplicationConfirmationOpen}
@@ -287,14 +308,6 @@ export const RoleForm = ({
                 />}
                 confirmLabel={<FormattedMessage id="stripes-core.button.continue" />}
               />
-
-              {!!unselectAllCapabilitiesAndSets && <Button
-                disabled={isLoading}
-                onClick={unselectAllCapabilitiesAndSets}
-              >
-                <FormattedMessage id="stripes-authorization-components.form.unassignAllCapabilities" />
-              </Button>}
-
               <CapabilitiesSetsAccordion
                 isCapabilitySetSelected={isCapabilitySetSelected}
                 onChangeCapabilitySetCheckbox={handleCapabilitySetCheckbox}

--- a/lib/Role/RoleForm/RoleForm.js
+++ b/lib/Role/RoleForm/RoleForm.js
@@ -17,7 +17,6 @@ import {
   TextArea,
   TextField,
   Row,
-  Col,
 } from '@folio/stripes/components';
 
 import { Pluggable } from '@folio/stripes/core';

--- a/lib/Role/RoleForm/RoleForm.test.js
+++ b/lib/Role/RoleForm/RoleForm.test.js
@@ -141,6 +141,8 @@ const defaultProps = {
   setIsUnselectApplicationConfirmationOpen: jest.fn(),
   unselectedItemsInfo: undefined,
   applyAppIdsChanges: jest.fn(),
+  showHidden: false,
+  setShowHidden: jest.fn(),
 };
 
 const renderComponent = (props = {}) => render(
@@ -349,5 +351,47 @@ describe('RoleForm', () => {
       'cap-3-view',
     );
     expect(defaultProps.toggleCapabilitiesHeaderCheckbox).toHaveBeenCalledWith(true, 'data', 'view');
+  });
+
+  describe('show hidden capabilities checkbox', () => {
+    const getShowHiddenCheckbox = () => screen.getByRole('checkbox', {
+      name: 'stripes-authorization-components.form.labels.showHidden',
+    });
+
+    it('renders unchecked when showHidden is false and calls setShowHidden on click', async () => {
+      renderComponent();
+
+      const checkbox = getShowHiddenCheckbox();
+
+      expect(checkbox).not.toBeChecked();
+
+      await userEvent.click(checkbox);
+
+      expect(defaultProps.setShowHidden).toHaveBeenCalledWith(true);
+    });
+
+    it('renders checked when showHidden is true', () => {
+      renderComponent({ showHidden: true });
+
+      expect(getShowHiddenCheckbox()).toBeChecked();
+    });
+
+    it('is disabled while the form is loading', () => {
+      renderComponent({ isLoading: true });
+
+      expect(getShowHiddenCheckbox()).toBeDisabled();
+    });
+
+    it('is disabled when there are no capabilities of any type', () => {
+      renderComponent({ capabilities: { data: [], procedural: [], settings: [] } });
+
+      expect(getShowHiddenCheckbox()).toBeDisabled();
+    });
+
+    it('is enabled when at least one capability type has entries', () => {
+      renderComponent();
+
+      expect(getShowHiddenCheckbox()).toBeEnabled();
+    });
   });
 });

--- a/lib/RoleDetails/RoleDetails.test.js
+++ b/lib/RoleDetails/RoleDetails.test.js
@@ -15,9 +15,11 @@ import {
   useDeleteRoleMutation,
   useInitialRoleSharing,
   useRoleById,
+  useRoleCapabilities,
+  useRoleCapabilitySets,
   useRoleSharing,
 } from '../hooks';
-import { isTenantConsortiumCentral } from '../utils';
+import { getCapabilitiesGroupedByTypeAndResource, isTenantConsortiumCentral } from '../utils';
 import { RoleDetails } from './RoleDetails';
 
 const mockHistoryPushFn = jest.fn();
@@ -28,6 +30,8 @@ jest.mock('../hooks', () => ({
   useDeleteRoleMutation: jest.fn(),
   useInitialRoleSharing: jest.fn(),
   useRoleById: jest.fn(),
+  useRoleCapabilities: jest.fn(),
+  useRoleCapabilitySets: jest.fn(),
   useRoleSharing: jest.fn(),
 }));
 jest.mock('../utils', () => ({
@@ -80,14 +84,27 @@ const mockMutateDeleteRole = jest.fn();
 
 useRoleById.mockReturnValue({ roleDetails: getRoleData(), isRoleDetailsLoaded: true });
 useDeleteRoleMutation.mockReturnValue({ mutateAsync: mockMutateDeleteRole });
-jest.mock('./RoleDetailsCapabilitiesAccordion', () => ({
-  RoleDetailsCapabilitiesAccordion: () => <div>Accordion capabilities</div>,
-}));
+// RoleDetailsCapabilitiesAccordion/RoleDetailsCapabilitySetsAccordion are left unmocked (see below)
+// so that the visibility-filtering tests can assert on what actually renders in the DOM.
+useRoleCapabilities.mockReturnValue({
+  initialRoleCapabilitiesSelectedMap: {},
+  isSuccess: true,
+  isFetching: false,
+  capabilitiesTotalCount: 0,
+  groupedRoleCapabilitiesByType: { data: [], procedural: [], settings: [] },
+  capabilitiesAppIds: {},
+});
+useRoleCapabilitySets.mockReturnValue({
+  initialRoleCapabilitySetsSelectedMap: {},
+  isSuccess: true,
+  isFetching: false,
+  capabilitySetsTotalCount: 0,
+  groupedRoleCapabilitySetsByType: { data: [], procedural: [], settings: [] },
+  capabilitySetsCapabilities: {},
+  capabilitySetsAppIds: {},
+});
 jest.mock('./RoleDetailsUsersAccordion', () => ({
   RoleDetailsUsersAccordion: () => <div>Accordion users</div>,
-}));
-jest.mock('./RoleDetailsCapabilitySetsAccordion', () => ({
-  RoleDetailsCapabilitySetsAccordion: () => <div>Accordion capability sets</div>,
 }));
 
 describe('RoleDetails component', () => {
@@ -109,8 +126,8 @@ describe('RoleDetails component', () => {
   describe('renders roles details pane with expanded information', () => {
     it('render expanded role info by default', () => {
       const { getByText } = renderComponent();
-      getByText('Accordion capabilities');
-      getByText('Accordion capability sets');
+      getByText('stripes-authorization-components.details.capabilities');
+      getByText('stripes-authorization-components.details.capabilitySets');
       getByText('Accordion users');
     });
 
@@ -151,6 +168,87 @@ describe('RoleDetails component', () => {
 
       await userEvent.click(getByText('stripes-authorization-components.crud.edit'));
       expect(mockHistoryPushFn).toHaveBeenCalledWith(path + '/2efe1d13-eff9-4b01-a2fe-512e9d5239c7/edit');
+    });
+  });
+
+  describe('capabilities and capability sets visibility filtering', () => {
+    const visibleCapability = {
+      id: 'cap-visible',
+      name: 'visible_resource.view',
+      resource: 'Visible Resource',
+      action: 'view',
+      applicationId: 'app-1',
+      type: 'data',
+      visible: true,
+    };
+    const hiddenCapability = {
+      id: 'cap-hidden',
+      name: 'hidden_resource.view',
+      resource: 'Hidden Resource',
+      action: 'view',
+      applicationId: 'app-1',
+      type: 'data',
+      visible: false,
+    };
+    const visibleCapabilitySet = {
+      id: 'cap-set-visible',
+      name: 'visible_set.view',
+      resource: 'Visible Resource Set',
+      action: 'view',
+      applicationId: 'app-1',
+      type: 'data',
+      visible: true,
+    };
+    const hiddenCapabilitySet = {
+      id: 'cap-set-hidden',
+      name: 'hidden_set.view',
+      resource: 'Hidden Resource Set',
+      action: 'view',
+      applicationId: 'app-1',
+      type: 'data',
+      visible: false,
+    };
+
+    beforeEach(() => {
+      // Mirror the real hooks' behavior of filtering the raw capabilities/sets by the
+      // predicate (isCapabilityVisible, hardcoded by the read-only accordions) before
+      // grouping them for display, so the test observes the effect on what's actually
+      // rendered rather than asserting on the predicate itself.
+      useRoleCapabilities.mockImplementation((_roleId, _tenant, _expand, _options, filter = () => true) => {
+        const filtered = [visibleCapability, hiddenCapability].filter(filter);
+
+        return {
+          initialRoleCapabilitiesSelectedMap: {},
+          isSuccess: true,
+          isFetching: false,
+          capabilitiesTotalCount: filtered.length,
+          groupedRoleCapabilitiesByType: getCapabilitiesGroupedByTypeAndResource(filtered),
+          capabilitiesAppIds: {},
+        };
+      });
+
+      useRoleCapabilitySets.mockImplementation((_roleId, _tenant, _options, filter = () => true) => {
+        const filtered = [visibleCapabilitySet, hiddenCapabilitySet].filter(filter);
+
+        return {
+          initialRoleCapabilitySetsSelectedMap: {},
+          isSuccess: true,
+          isFetching: false,
+          capabilitySetsTotalCount: filtered.length,
+          groupedRoleCapabilitySetsByType: getCapabilitiesGroupedByTypeAndResource(filtered),
+          capabilitySetsCapabilities: {},
+          capabilitySetsAppIds: {},
+        };
+      });
+    });
+
+    it('renders capabilities and capability sets that are visible, and omits those marked visible: false', () => {
+      const { getByText, queryByText } = renderComponent();
+
+      expect(getByText('Visible Resource')).toBeInTheDocument();
+      expect(queryByText('Hidden Resource')).not.toBeInTheDocument();
+      expect(getByText('Visible Resource Set')).toBeInTheDocument();
+      expect(queryByText('Hidden Resource Set')).not.toBeInTheDocument();
     });
   });
 

--- a/lib/RoleDetails/RoleDetailsCapabilitiesAccordion/RoleDetailsCapabilitiesAccordion.js
+++ b/lib/RoleDetails/RoleDetailsCapabilitiesAccordion/RoleDetailsCapabilitiesAccordion.js
@@ -9,6 +9,7 @@ import {
 
 import { CapabilitiesSection } from '../../Capabilities';
 import { useRoleCapabilities } from '../../hooks';
+import { isCapabilityVisible } from '../../utils';
 
 export const RoleDetailsCapabilitiesAccordion = ({ roleId, tenantId }) => {
   const {
@@ -16,7 +17,7 @@ export const RoleDetailsCapabilitiesAccordion = ({ roleId, tenantId }) => {
     initialRoleCapabilitiesSelectedMap,
     groupedRoleCapabilitiesByType,
     isSuccess
-  } = useRoleCapabilities(roleId, tenantId, true);
+  } = useRoleCapabilities(roleId, tenantId, true, {}, isCapabilityVisible);
 
   if (!isSuccess) {
     return <Loading />;

--- a/lib/RoleDetails/RoleDetailsCapabilitySetsAccordion/RoleDetailsCapabilitySetsAccordion.js
+++ b/lib/RoleDetails/RoleDetailsCapabilitySetsAccordion/RoleDetailsCapabilitySetsAccordion.js
@@ -9,6 +9,7 @@ import {
 
 import { CapabilitiesSection } from '../../Capabilities';
 import { useRoleCapabilitySets } from '../../hooks';
+import { isCapabilityVisible } from '../../utils';
 
 export const RoleDetailsCapabilitySetsAccordion = ({ roleId, tenantId }) => {
   const {
@@ -16,7 +17,7 @@ export const RoleDetailsCapabilitySetsAccordion = ({ roleId, tenantId }) => {
     capabilitySetsTotalCount,
     initialRoleCapabilitySetsSelectedMap,
     isSuccess
-  } = useRoleCapabilitySets(roleId, tenantId);
+  } = useRoleCapabilitySets(roleId, tenantId, {}, isCapabilityVisible);
 
   if (!isSuccess) {
     return <Loading />;

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -35,6 +35,7 @@ function removeUncheckedCaps(checkedAppCaps) {
  *   this object, the hook will retrieve the capabilities for the selected applications.
  * @param {Object} options - query options.
  * @param {Function} setDisabledCapabilities - disabled capabilities setter function.
+ * @param {Function} filter - sets a client-side filter for the capabilities. Should return a boolean.
  * @return {Object} An object containing the following properties:
  *   - capabilities: An object containing the capabilities grouped by type and resource.
  *   - selectedCapabilitiesMap: An object containing the selected capabilities mapped by their IDs.
@@ -49,6 +50,7 @@ export const useApplicationCapabilities = ({
   checkedAppIdsMap,
   options = {},
   setDisabledCapabilities,
+  filter = (_capability) => true,
 }) => {
   const { tenantId } = options;
 
@@ -59,36 +61,41 @@ export const useApplicationCapabilities = ({
     queryKeys,
   } = useChunkedApplicationCapabilities(selectedAppIds, { tenantId });
 
+  const filteredCapabilities = useMemo(() => {
+    if (!capabilities) return [];
+    return capabilities?.filter(filter) || [];
+  }, [capabilities, filter]);
+
   const [selectedCapabilitiesMap, setSelectedCapabilitiesMap] = useState({});
   const roleCapabilitiesListIds = extractSelectedIdsFromObject(selectedCapabilitiesMap);
 
   const roleCapabilitiesListNames = useMemo(() => {
-    const capabilitiesMap = keyBy(capabilities, 'id');
+    const capabilitiesMap = keyBy(filteredCapabilities, 'id');
 
     return roleCapabilitiesListIds
       .map((capabilityId) => capabilitiesMap[capabilityId]?.name)
       .filter(Boolean);
-  }, [capabilities, roleCapabilitiesListIds]);
+  }, [filteredCapabilities, roleCapabilitiesListIds]);
 
-  const memoizedCapabilities = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilities), [capabilities]);
+  const memoizedCapabilities = useMemo(() => getCapabilitiesGroupedByTypeAndResource(filteredCapabilities), [filteredCapabilities]);
 
   const actionCapabilities = useMemo(() => {
     const initialStructure = { data: {}, settings: {}, procedural: {} };
 
-    return capabilities.reduce((acc, { type, action, id }) => {
+    return filteredCapabilities.reduce((acc, { type, action, id }) => {
       if (!acc[type][action]) acc[type][action] = [];
       acc[type][action].push(id);
 
       return acc;
     }, initialStructure);
-  }, [capabilities]);
+  }, [filteredCapabilities]);
 
   const checkedAppCaps = useMemo(
-    () => capabilities.reduce((acc, capSet) => {
+    () => filteredCapabilities.reduce((acc, capSet) => {
       acc[capSet.id] = true;
       return acc;
     }, {}),
-    [capabilities],
+    [filteredCapabilities],
   );
 
   /*

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -12,6 +12,8 @@ import {
 } from '../../utils';
 import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapabilities';
 
+const defaultFilter = (_capability) => true;
+
 function removeUncheckedCaps(checkedAppCaps) {
   return (prevCaps) => {
     const copy = { ...prevCaps };
@@ -50,7 +52,7 @@ export const useApplicationCapabilities = ({
   checkedAppIdsMap,
   options = {},
   setDisabledCapabilities,
-  filter = (_capability) => true,
+  filter = defaultFilter,
 }) => {
   const { tenantId } = options;
 

--- a/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
+++ b/lib/hooks/useApplicationCapabilities/useApplicationCapabilities.js
@@ -12,6 +12,7 @@ import {
 } from '../../utils';
 import { useChunkedApplicationCapabilities } from '../useChunkedApplicationCapabilities';
 
+// seting defaultFilter as const to avoid creating a new function on every render.
 const defaultFilter = (_capability) => true;
 
 function removeUncheckedCaps(checkedAppCaps) {

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -49,7 +49,7 @@ export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {}, f
     return roleCapabilitySetsListIds
       .map((capabilitySetId) => capabilitySetsMap[capabilitySetId]?.name)
       .filter(Boolean);
-  }, [capabilitySets, roleCapabilitySetsListIds]);
+  }, [capabilitySets, roleCapabilitySetsListIds, filteredCapabilitySets]);
 
   const memoizedCapabilitySets = useMemo(() => getCapabilitiesGroupedByTypeAndResource(filteredCapabilitySets), [filteredCapabilitySets]);
 

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -13,6 +13,7 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
  * @param {Object} checkedAppIdsMap - An object mapping application IDs to boolean values indicating whether they are checked.
  *   Using this object, the hook will fetch the capability sets for the selected applications.
  * @param {Object} options - An object that could include tenantId and other information
+ * @param {Function} filter - A function used as a client-side filter for capability sets. Should return a boolean.
  * @return {Object} An object containing the following properties:
  *   - capabilitySets: An object grouping capability sets by type and resource.
  *   - capabilitySetsList: An array of capability sets.
@@ -22,7 +23,7 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
  *   - isLoading: A boolean indicating whether capability sets are currently being fetched.
  */
 
-export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} }) => {
+export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {}, filter = () => true }) => {
   const { tenantId } = options;
 
   const selectedAppIds = Object.keys(checkedAppIdsMap);
@@ -32,36 +33,40 @@ export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} })
     queryKeys = [],
   } = useChunkedApplicationCapabilitySets(selectedAppIds, { tenantId });
 
+  const filteredCapabilitySets = useMemo(() => {
+    return capabilitySets ? capabilitySets.filter(filter) : [];
+  }, [capabilitySets, filter]);
+
   const [selectedCapabilitySetsMap, setSelectedCapabilitySetsMap] = useState({});
   const roleCapabilitySetsListIds = Object.keys(selectedCapabilitySetsMap);
 
   const roleCapabilitySetsListNames = useMemo(() => {
-    const capabilitySetsMap = keyBy(capabilitySets, 'id');
+    const capabilitySetsMap = keyBy(filteredCapabilitySets, 'id');
 
     return roleCapabilitySetsListIds
       .map((capabilitySetId) => capabilitySetsMap[capabilitySetId]?.name)
       .filter(Boolean);
   }, [capabilitySets, roleCapabilitySetsListIds]);
 
-  const memoizedCapabilitySets = useMemo(() => getCapabilitiesGroupedByTypeAndResource(capabilitySets), [capabilitySets]);
+  const memoizedCapabilitySets = useMemo(() => getCapabilitiesGroupedByTypeAndResource(filteredCapabilitySets), [filteredCapabilitySets]);
 
   const actionCapabilitySets = useMemo(() => {
     const initialStructure = { data: {}, settings: {}, procedural: {} };
 
-    return capabilitySets.reduce((acc, { type, action, id }) => {
+    return filteredCapabilitySets.reduce((acc, { type, action, id }) => {
       if (!acc[type][action]) acc[type][action] = [];
       acc[type][action].push(id);
 
       return acc;
     }, initialStructure);
-  }, [capabilitySets]);
+  }, [filteredCapabilitySets]);
 
   const checkedAppCapSets = useMemo(
-    () => capabilitySets.reduce((acc, capSet) => {
+    () => filteredCapabilitySets.reduce((acc, capSet) => {
       acc[capSet.id] = true;
       return acc;
     }, {}),
-    [capabilitySets],
+    [filteredCapabilitySets],
   );
 
   /*
@@ -99,7 +104,7 @@ export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {} })
 
   return {
     capabilitySets: memoizedCapabilitySets,
-    capabilitySetsList: capabilitySets,
+    capabilitySetsList: filteredCapabilitySets,
     selectedCapabilitySetsMap,
     setSelectedCapabilitySetsMap,
     roleCapabilitySetsListIds,

--- a/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
+++ b/lib/hooks/useApplicationCapabilitySets/useApplicationCapabilitySets.js
@@ -23,7 +23,10 @@ import { useChunkedApplicationCapabilitySets } from '../useChunkedApplicationCap
  *   - isLoading: A boolean indicating whether capability sets are currently being fetched.
  */
 
-export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {}, filter = () => true }) => {
+// seting defaultFilter as const to avoid creating a new function on every render.
+const defaultFilter = (_capabilitySet) => true;
+
+export const useApplicationCapabilitySets = ({ checkedAppIdsMap, options = {}, filter = defaultFilter }) => {
   const { tenantId } = options;
 
   const selectedAppIds = Object.keys(checkedAppIdsMap);

--- a/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
+++ b/lib/hooks/useRoleCapabilities/useRoleCapabilities.js
@@ -26,9 +26,14 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  * @param {boolean} expand Defines if capability sets must be expanded in the API response. Defaults to `false`.
  * with expand=false API returns capabilities that was assigned directly, not by capability set.
  * @param {object} options Any additional options to pass into `useQuery()`.
+ * @param {Function} filter - client-side predicate (capability) => boolean, applied on top of the
+ *   fetched capabilities before deriving `initialRoleCapabilitiesSelectedMap`, `groupedRoleCapabilitiesByType`,
+ *   and `initialRoleCapabilitiesNames`. Defaults to `() => true` (no filtering). Deliberately NOT applied to
+ *   `capabilitiesAppIds`, since app-picker membership shouldn't disappear just because all of an app's
+ *   capabilities are filtered out (e.g. hidden).
  * @returns Capabilities.
  */
-export const useRoleCapabilities = (roleId, tenant = '', expand = false, options = {}) => {
+export const useRoleCapabilities = (roleId, tenant = '', expand = false, options = {}, filter = (_capability) => true) => {
   const { enabled = true, ...otherOptions } = options;
   const stripes = useStripes();
   const installedApplications = Object.keys(stripes.discovery.applications);
@@ -51,18 +56,21 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
     ...otherOptions,
   });
 
+  const filteredCapabilities = useMemo(() => {
+    return (data?.capabilities || []).filter(filter);
+  }, [data, filter]);
+
   const initialRoleCapabilitiesSelectedMap = useMemo(() => {
-    if (!data) return {};
-    return data?.capabilities.reduce((acc, capability) => {
+    return filteredCapabilities.reduce((acc, capability) => {
       acc[capability.id] = true;
 
       return acc;
-    }, {}) || {};
-  }, [data]);
+    }, {});
+  }, [filteredCapabilities]);
 
   const groupedRoleCapabilitiesByType = useMemo(() => {
-    return getCapabilitiesGroupedByTypeAndResource(data?.capabilities || []);
-  }, [data]);
+    return getCapabilitiesGroupedByTypeAndResource(filteredCapabilities);
+  }, [filteredCapabilities]);
 
   const capabilitiesAppIds = useMemo(() => {
     if (!data) return {};
@@ -74,8 +82,8 @@ export const useRoleCapabilities = (roleId, tenant = '', expand = false, options
   }, [data]);
 
   const initialRoleCapabilitiesNames = useMemo(() => {
-    return data?.capabilities?.map(({ name }) => name);
-  }, [data]);
+    return filteredCapabilities.map(({ name }) => name);
+  }, [filteredCapabilities]);
 
   return {
     initialRoleCapabilitiesSelectedMap,

--- a/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
+++ b/lib/hooks/useRoleCapabilitySets/useRoleCapabilitySets.js
@@ -24,9 +24,14 @@ import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
  * @param {string} roleId The Role ID.
  * @param {string} tenant The Tenant ID. Passes into `useOkapiKy` which will default to `stripes.okapi.tenant` if omitted.
  * @param {object} options Any additional options to pass into `useQuery()`.
+ * @param {Function} filter - client-side predicate (capabilitySet) => boolean, applied on top of the
+ *   fetched capability sets before deriving `initialRoleCapabilitySetsSelectedMap` and `groupedRoleCapabilitySetsByType`.
+ *   Defaults to `() => true` (no filtering). Deliberately NOT applied to `capabilitySetsCapabilities` or
+ *   `capabilitySetsAppIds` — the disabled-capabilities bookkeeping and app-picker membership shouldn't
+ *   change just because a set is filtered out (e.g. hidden) from the grid.
  * @returns Capability Sets.
  */
-export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
+export const useRoleCapabilitySets = (roleId, tenant = '', options = {}, filter = (_capabilitySet) => true) => {
   const { enabled = true, ...otherOptions } = options;
   const stripes = useStripes();
   const installedApplications = Object.keys(stripes.discovery.applications);
@@ -40,17 +45,21 @@ export const useRoleCapabilitySets = (roleId, tenant = '', options = {}) => {
     ...otherOptions,
   });
 
+  const filteredCapabilitySets = useMemo(() => {
+    return (data?.capabilitySets || []).filter(filter);
+  }, [data, filter]);
+
   const initialRoleCapabilitySetsSelectedMap = useMemo(() => {
-    return data?.capabilitySets.reduce((acc, capability) => {
+    return filteredCapabilitySets.reduce((acc, capability) => {
       acc[capability.id] = true;
 
       return acc;
-    }, {}) || {};
-  }, [data]);
+    }, {});
+  }, [filteredCapabilitySets]);
 
   const groupedRoleCapabilitySetsByType = useMemo(() => {
-    return getCapabilitiesGroupedByTypeAndResource(data?.capabilitySets || []);
-  }, [data]);
+    return getCapabilitiesGroupedByTypeAndResource(filteredCapabilitySets);
+  }, [filteredCapabilitySets]);
 
   /* We need to determine how many times a specific capability is included in various capability sets
   to initialize the disabled capabilities

--- a/lib/utils/filters.js
+++ b/lib/utils/filters.js
@@ -1,0 +1,23 @@
+/**
+ * Combines multiple predicate functions into a single predicate that returns
+ * true only if every predicate returns true (logical AND). Falsy entries in
+ * `filters` are ignored, so callers can conditionally include filters, e.g.
+ * `composeFilters(byVisibility, searchTerm && byName(searchTerm))`.
+ *
+ * @param {...Function} filters - predicate functions of shape (item) => boolean
+ * @returns {Function} combined predicate
+ */
+export const composeFilters = (...filters) => {
+  const activeFilters = filters.filter(Boolean);
+
+  return (item) => activeFilters.every((filterFn) => filterFn(item));
+};
+
+/**
+ * Predicate matching capabilities/capability sets that aren't explicitly hidden.
+ * A capability without a `visible` property is treated as visible.
+ *
+ * @param {Object} capability - a capability or capability set
+ * @returns {boolean}
+ */
+export const isCapabilityVisible = (capability) => capability.visible !== false;

--- a/lib/utils/filters.test.js
+++ b/lib/utils/filters.test.js
@@ -1,0 +1,50 @@
+import { composeFilters, isCapabilityVisible } from './filters';
+
+describe('isCapabilityVisible', () => {
+  it('returns true when visible is undefined', () => {
+    expect(isCapabilityVisible({})).toBe(true);
+  });
+
+  it('returns true when visible is explicitly true', () => {
+    expect(isCapabilityVisible({ visible: true })).toBe(true);
+  });
+
+  it('returns false when visible is explicitly false', () => {
+    expect(isCapabilityVisible({ visible: false })).toBe(false);
+  });
+});
+
+describe('composeFilters', () => {
+  it('returns true for every item when called with no filters', () => {
+    const combined = composeFilters();
+
+    expect(combined({})).toBe(true);
+    expect(combined({ visible: false })).toBe(true);
+  });
+
+  it('combines multiple predicates with logical AND', () => {
+    const isEven = (item) => item.value % 2 === 0;
+    const isPositive = (item) => item.value > 0;
+    const combined = composeFilters(isEven, isPositive);
+
+    expect(combined({ value: 4 })).toBe(true);
+    expect(combined({ value: -4 })).toBe(false);
+    expect(combined({ value: 3 })).toBe(false);
+  });
+
+  it('ignores falsy filters so callers can conditionally include them', () => {
+    const isVisible = (item) => item.visible !== false;
+    const combined = composeFilters(isVisible, false, undefined, null);
+
+    expect(combined({ visible: true })).toBe(true);
+    expect(combined({ visible: false })).toBe(false);
+  });
+
+  it('returns a predicate reflecting isCapabilityVisible when used as the only filter', () => {
+    const combined = composeFilters(isCapabilityVisible);
+
+    expect(combined({ visible: false })).toBe(false);
+    expect(combined({ visible: true })).toBe(true);
+    expect(combined({})).toBe(true);
+  });
+});

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,7 @@
 export * from './api';
 export * from './consortia';
 export * from './errorHandling';
+export * from './filters';
 export * from './grouping';
 export * from './helpers';
 export { isShared } from './isShared';

--- a/translations/stripes-authorization-components/en.json
+++ b/translations/stripes-authorization-components/en.json
@@ -54,6 +54,7 @@
   "form.labels.sourceType.user": "User",
   "form.labels.sourceType.system": "System",
   "form.labels.sourceType.consortium": "Consortium",
+  "form.labels.showHidden": "Show hidden capabilities",
   "applications.select": "Select application",
   "applications.found": "{count} applications found",
   "applications.totalSelected": "Total selected: {count}",
@@ -73,7 +74,6 @@
   "policy.share.error": "Policy could not be shared",
   "policyDetails.columns.name": "Name",
   "policyDetails.columns.description": "Description",
-
   "role.create.success": "Role has been created successfully",
   "role.create.error": "Role could not be created",
   "role.delete.success": "Role has been deleted successfully",
@@ -88,9 +88,7 @@
   "role.type.support": "Support",
   "role.type.regular": "Regular",
   "role.type.consortium": "Consortium",
-
   "consortiumManager.modal.confirmShare.all.message": "<p>Are you sure you want to share {term} with <b>ALL</b> members? </p><p> Please note: Sharing a role with many capabilities or capability sets can take several minutes to complete, especially in systems with a large number of members. Avoid refreshing or closing this page during the process.</p>",
-
   "filter.true": "Yes",
   "filter.false": "No",
   "shareToAll": "Share to all",


### PR DESCRIPTION
## [UISAUTHCOM-101](https://folio-org.atlassian.net/browse/UISAUTHCOM-101)

### Purpose
Reduce the amount of capabilities rendered in the UI based on the `visible` field from mod-roles-kc.

### Approach
Add a `filter` parameter to the capabilities/capabilitySet hooks so that each view can apply their individual client-side filter logic according to their needs. Implemented a small `isCapabilityVisible` filter for shared code. The filter is applied unconditionally on the `RoleDetails` page (`CapabilitiesAccordion`, `CapabilitySetsAccordion`) and uses a `<Checkbox>` on the `RoleForm` for the Edit and Create views.

Add: once #154 merges, we can probably consolidate the implementation of that to use the filters setup, rather than the 'direct' output fields implemented there.

## Result: (video should show up here, but maybe gh is not happy atm)
https://github.com/user-attachments/assets/cfa314a7-f3e7-414e-a5c9-fa951cec2a68
